### PR TITLE
fix: resolve issues #4, #5, #6, #7, #8 (change-005, v3.1.0)

### DIFF
--- a/app/db_manager.py
+++ b/app/db_manager.py
@@ -148,15 +148,17 @@ class DatabaseManager:
 
         Currently handles:
           - Adding 'role' column to users table if missing (upgrade from change-003).
+          - Adding 'logs' column to scans table if missing (Issue #7 — persist execution logs).
         """
         with self._lock:
             conn = self.get_connection()
             try:
-                columns = {
+                # Migration: users.role column (change-003 upgrade)
+                user_columns = {
                     row[1]
                     for row in conn.execute("PRAGMA table_info(users)").fetchall()
                 }
-                if "role" not in columns:
+                if "role" not in user_columns:
                     conn.execute(
                         "ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'operator'"
                     )
@@ -166,6 +168,16 @@ class DatabaseManager:
                     )
                     conn.commit()
                     logger.info("Migration: added 'role' column to users table")
+
+                # Migration: scans.logs column (Issue #7 — execution log persistence)
+                scan_columns = {
+                    row[1]
+                    for row in conn.execute("PRAGMA table_info(scans)").fetchall()
+                }
+                if "logs" not in scan_columns:
+                    conn.execute("ALTER TABLE scans ADD COLUMN logs TEXT")
+                    conn.commit()
+                    logger.info("Migration: added 'logs' column to scans table")
             finally:
                 conn.close()
 

--- a/app/routes/scan_routes.py
+++ b/app/routes/scan_routes.py
@@ -202,6 +202,12 @@ def start_scan(audit_manager=None):
 
         scan_id = str(uuid.uuid4())
 
+        # Resolve username / ticket_id from session and audit_manager
+        username = session.get("user", "unknown")
+        ticket_id_val = 0
+        if audit_manager is not None:
+            ticket_id_val = int(getattr(audit_manager, "ticket_id", 0) or 0)
+
         # Get storage_manager from app config (may be None in tests without DB)
         storage_manager = current_app.config.get("scan_storage_manager")
 
@@ -226,22 +232,17 @@ def start_scan(audit_manager=None):
             "config": config,
             "status": "started",
             "progress": 0,
+            "ticket_id": ticket_id_val,
         }
 
         # Persist initial scan record to SQLite
         if storage_manager is not None:
             try:
-                # Resolve username / user_id from session
-                username = session.get("user", "unknown")
-                ticket_id_val = 0
-                if audit_manager is not None:
-                    ticket_id_val = getattr(audit_manager, "ticket_id", 0) or 0
-
                 storage_manager.save_scan(
                     scan_id,
                     {
                         "username": username,
-                        "ticket_id": int(ticket_id_val),
+                        "ticket_id": ticket_id_val,
                         "scan_type": "AP_SM_CROSS" if sm_ips else "AP_ONLY",
                         "ap_ips": ap_ips,
                         "sm_ips": sm_ips if sm_ips else None,
@@ -318,6 +319,7 @@ def get_scan_status(scan_id: str):
         "status": scan_data.get("status", "unknown"),
         "progress": scan_data.get("progress", 0),
         "error": scan_data.get("error"),
+        "logs": scan_data.get("logs") or [],
     }
 
     if scan_data.get("status") == "completed":
@@ -405,6 +407,7 @@ def list_scans():
                 "status": task.status,
                 "progress": task.progress,
                 "ap_count": len(scan_data["ap_ips"]),
+                "ticket_id": scan_data.get("ticket_id", 0),
             }
         )
         seen_ids.add(scan_id)
@@ -426,6 +429,7 @@ def list_scans():
                     "status": scan_row.get("status", "unknown"),
                     "progress": 0,
                     "ap_count": ap_count,
+                    "ticket_id": scan_row.get("ticket_id", 0),
                 }
             )
 

--- a/app/scan_storage_manager.py
+++ b/app/scan_storage_manager.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 # Fields that are stored as JSON in the DB and deserialized on read
-_JSON_FIELDS = ("ap_ips", "sm_ips", "config", "results", "recommendations")
+_JSON_FIELDS = ("ap_ips", "sm_ips", "config", "results", "recommendations", "logs")
 
 
 def _serialize(value):
@@ -66,9 +66,9 @@ class ScanStorageManager:
             data: Dict that may contain any of:
                 username, ticket_id, scan_type, ap_ips, sm_ips, config,
                 status, progress, results, error, completed_at,
-                duration_seconds, tower_id, user_id, recommendations.
+                duration_seconds, tower_id, user_id, recommendations, logs.
                 ap_ips/sm_ips are serialized as JSON if they are lists.
-                config/results/recommendations are serialized as JSON if dicts/lists.
+                config/results/recommendations/logs are serialized as JSON if dicts/lists.
 
         Notes:
             - Uses INSERT OR REPLACE (UPSERT) semantics.
@@ -95,6 +95,7 @@ class ScanStorageManager:
             if data.get("recommendations") is not None
             else None
         )
+        logs = _serialize(data.get("logs")) if data.get("logs") is not None else None
         tower_id = data.get("tower_id")
         user_id = data.get("user_id")
         completed_at = data.get("completed_at")
@@ -110,7 +111,34 @@ class ScanStorageManager:
                         """INSERT OR REPLACE INTO scans
                            (id, tower_id, user_id, username, ticket_id, scan_type,
                             status, ap_ips, sm_ips, config, results, recommendations,
-                            started_at, completed_at, duration_seconds, error)
+                            logs, started_at, completed_at, duration_seconds, error)
+                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                        (
+                            scan_id,
+                            tower_id,
+                            user_id,
+                            username,
+                            ticket_id,
+                            scan_type,
+                            status,
+                            ap_ips,
+                            sm_ips,
+                            config,
+                            results,
+                            recommendations,
+                            logs,
+                            started_at,
+                            completed_at,
+                            duration_seconds,
+                            error,
+                        ),
+                    )
+                else:
+                    conn.execute(
+                        """INSERT OR REPLACE INTO scans
+                           (id, tower_id, user_id, username, ticket_id, scan_type,
+                            status, ap_ips, sm_ips, config, results, recommendations,
+                            logs, completed_at, duration_seconds, error)
                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                         (
                             scan_id,
@@ -125,32 +153,7 @@ class ScanStorageManager:
                             config,
                             results,
                             recommendations,
-                            started_at,
-                            completed_at,
-                            duration_seconds,
-                            error,
-                        ),
-                    )
-                else:
-                    conn.execute(
-                        """INSERT OR REPLACE INTO scans
-                           (id, tower_id, user_id, username, ticket_id, scan_type,
-                            status, ap_ips, sm_ips, config, results, recommendations,
-                            completed_at, duration_seconds, error)
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                        (
-                            scan_id,
-                            tower_id,
-                            user_id,
-                            username,
-                            ticket_id,
-                            scan_type,
-                            status,
-                            ap_ips,
-                            sm_ips,
-                            config,
-                            results,
-                            recommendations,
+                            logs,
                             completed_at,
                             duration_seconds,
                             error,
@@ -254,6 +257,7 @@ class ScanStorageManager:
         scan_id: str,
         results: dict,
         duration_seconds: float = None,
+        logs: list = None,
     ) -> None:
         """Mark a scan as completed and persist its results.
 
@@ -261,21 +265,32 @@ class ScanStorageManager:
             scan_id:          Unique scan identifier.
             results:          Final results dict to store (serialized as JSON).
             duration_seconds: Optional elapsed time in seconds.
+            logs:             Optional list of log entries to persist (Issue #7).
         """
         now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
         results_json = _serialize(results)
+        logs_json = _serialize(logs) if logs is not None else None
+
+        sets = [
+            "status = 'completed'",
+            "results = ?",
+            "completed_at = ?",
+            "duration_seconds = ?",
+        ]
+        params = [results_json, now, duration_seconds]
+
+        if logs_json is not None:
+            sets.append("logs = ?")
+            params.append(logs_json)
+
+        params.append(scan_id)
 
         with self.db._lock:
             conn = self.db.get_connection()
             try:
                 conn.execute(
-                    """UPDATE scans
-                       SET status = 'completed',
-                           results = ?,
-                           completed_at = ?,
-                           duration_seconds = ?
-                       WHERE id = ?""",
-                    (results_json, now, duration_seconds, scan_id),
+                    f"UPDATE scans SET {', '.join(sets)} WHERE id = ?",
+                    params,
                 )
                 conn.commit()
             except Exception:

--- a/app/scan_task.py
+++ b/app/scan_task.py
@@ -561,7 +561,10 @@ class ScanTask:
             if self.storage_manager is not None:
                 try:
                     self.storage_manager.complete_scan(
-                        self.scan_id, self.results, duration_seconds=duration
+                        self.scan_id,
+                        self.results,
+                        duration_seconds=duration,
+                        logs=self.logs,
                     )
                     logger.info(f"[{self.scan_id}] Resultados guardados en DB storage")
                 except Exception as exc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - CNMAESTRO_SECRET=${CNMAESTRO_SECRET}
       # Base de datos unificada (v3.0.0 — reemplaza AUTH_DB_PATH + STORAGE_FILE_PATH)
       - DB_PATH=/app/data/analyzer.db
+      # Zona horaria del contenedor (Issue #8 — sincronizar con host)
+      - TZ=${TZ:-America/Mexico_City}
     volumes:
       # Mapear código fuente para desarrollo
       - ./app:/app/app

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -645,6 +645,18 @@ details summary:hover {
     .advanced-fields {
         grid-template-columns: 1fr;
     }
+
+    /* Issue #6 — Log de Ejecución: altura mínima en móvil */
+    .log-output {
+        max-height: 200px;
+        min-height: 100px;
+    }
+}
+
+/* Issue #6 — Log de Ejecución: evitar colapso en layouts flex vh-100 */
+#logOutput {
+    min-height: 120px;
+    flex-shrink: 0;
 }
 
 /* Scrollbar */

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -767,6 +767,17 @@ function addLogEntry(msg, type = 'info', detailed = false) {
 }
 
 function resetInterface() {
+    // Stop any active polling
+    if (appState.pollInterval) {
+        clearInterval(appState.pollInterval);
+        appState.pollInterval = null;
+    }
+    // Reset all application state (Issue #5)
+    appState.currentScanId = null;
+    appState.scanResults = null;
+    appState.lastLogCount = 0;
+    // chartInstance is kept — it will be replaced on next displayResults()
+
     elements.resultsPanel.style.display = 'none';
     elements.statusPanel.style.display = 'none';
     elements.welcomePanel.style.display = 'block';

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -99,6 +99,7 @@ async function renderHistoryPanel() {
             const badgeColor = statusColors[scan.status] || 'secondary';
             const shortId = scan.scan_id ? scan.scan_id.substring(0, 12) + '...' : 'N/A';
             const isCompleted = scan.status === 'completed';
+            const ticketDisplay = scan.ticket_id ? `#${scan.ticket_id}` : '—';
 
             return `
                 <tr class="${isCompleted ? 'scan-row-clickable' : 'opacity-75'}"
@@ -108,6 +109,7 @@ async function renderHistoryPanel() {
                     <td class="small align-middle">${date}</td>
                     <td class="align-middle"><span class="badge bg-${badgeColor}">${scan.status || 'unknown'}</span></td>
                     <td class="text-center align-middle">${scan.ap_count || 0}</td>
+                    <td class="text-center align-middle text-info small">${escapeHtml(ticketDisplay)}</td>
                     <td class="align-middle">
                         ${isCompleted
                             ? `<button class="btn btn-outline-info btn-sm"
@@ -129,6 +131,7 @@ async function renderHistoryPanel() {
                             <th>Fecha</th>
                             <th>Estado</th>
                             <th class="text-center">APs</th>
+                            <th class="text-center">Ticket</th>
                             <th>Acción</th>
                         </tr>
                     </thead>

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -111,6 +111,7 @@ class TestSchemaCreation:
             "config",
             "results",
             "recommendations",
+            "logs",
             "started_at",
             "completed_at",
             "duration_seconds",


### PR DESCRIPTION
- #4 (ticket_id ausente en historial): ticket_id propagado en active_scans, list_scans() fuente memoria y SQLite, columna Ticket en history.js
- #5 (estado sucio tras nuevo escaneo): resetInterface() limpia appState completo (polling, currentScanId, scanResults, lastLogCount)
- #6 (log de ejecucion no responsive): media queries en style.css para log-output en pantallas pequeñas (max-height 200px)
- #7 (logs perdidos al recargar): migracion idempotente columna logs en scans, _JSON_FIELDS actualizado, save_scan/complete_scan persisten logs, scan_task.py pasa logs al completar, fallback SQLite devuelve logs
- #8 (zona horaria UTC en Docker): TZ=${TZ:-America/Mexico_City} en docker-compose.yml
- test: test_scans_table_has_expected_columns incluye columna logs