### PR TITLE
feat: change-006 frontend refactor (v3.2.0)

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,14 +7,14 @@
     <title>Tower Scan - PMP 450i Analyzer</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=9">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=10">
 </head>
 
 <body>
     <!-- Inject user role for JS -->
     <script>window.userRole = "{{ session.get('role', 'operator') }}";</script>
 
-    <div class="container-fluid p-4 d-flex flex-column vh-100" style="overflow: hidden;">
+    <div class="container-fluid p-3 p-md-4 d-flex flex-column main-container">
         <!-- Header -->
         <header class="header mb-2 text-center position-relative" style="padding: 15px 20px;">
             <div class="position-absolute top-0 end-0 p-3">
@@ -56,13 +56,13 @@
             </li>
         </ul>
 
-        <div class="tab-content flex-grow-1" style="min-height: 0; overflow: hidden;">
+        <div class="tab-content flex-grow-1 tab-content-responsive">
 
             <!-- ==================== PANEL ESCANEO (existing) ==================== -->
-            <div class="tab-pane fade show active h-100" id="panel-scan" role="tabpanel">
-                <div class="row g-3 h-100" style="min-height: 0;">
+            <div class="tab-pane fade show active panel-scan-responsive" id="panel-scan" role="tabpanel">
+                <div class="row g-3 scan-row-responsive" style="min-height: 0;">
                     <!-- Left Column: Config + Logs (Quadrants 1 & 3) -->
-                    <div class="col-md-6 d-flex flex-column gap-3 h-100">
+                    <div class="col-12 col-md-6 d-flex flex-column gap-3 col-scan-responsive">
                         <!-- Config Card (Auto Height) -->
                         <div class="card shadow-sm border-0 d-flex flex-column"
                             style="background: var(--card-bg); flex-shrink: 0;">
@@ -101,32 +101,7 @@
                                     </div>
                                 </div>
 
-                                <!-- Advanced Options -->
-                                <div class="accordion" id="advancedOptions">
-                                    <div class="accordion-item bg-transparent border-secondary">
-                                        <h2 class="accordion-header">
-                                            <button class="accordion-button collapsed bg-dark text-light py-2" type="button"
-                                                data-bs-toggle="collapse" data-bs-target="#collapseAdv">
-                                                <i class="bi bi-sliders me-2"></i> Opciones Avanzadas
-                                            </button>
-                                        </h2>
-                                        <div id="collapseAdv" class="accordion-collapse collapse"
-                                            data-bs-parent="#advancedOptions">
-                                            <div class="accordion-body text-light small">
-                                                <label class="form-label">Preferencias de Análisis</label>
-                                                <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox" id="prioritizeUplink"
-                                                        checked>
-                                                    <label class="form-check-label">Priorizar Uplink (CCTV)</label>
-                                                </div>
-                                                <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox" id="stabilityOverSpeed">
-                                                    <label class="form-check-label">Estabilidad > Velocidad</label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
+
 
                                 <!-- Recent History -->
                                 <div class="mt-4">
@@ -151,7 +126,7 @@
                                         for="detailedLogToggle">Verbose</label>
                                 </div>
                             </div>
-                            <div class="card-body p-0 d-flex flex-column overflow-hidden">
+                            <div class="card-body p-0 d-flex flex-column">
                                 <div id="logOutput" class="p-2 small font-monospace text-light flex-grow-1"
                                     style="overflow-y: auto; background: #1a1a1a;"></div>
                             </div>
@@ -159,7 +134,7 @@
                     </div>
 
                     <!-- Right Column: Targets + Results (Quadrants 2 & 4) -->
-                    <div class="col-md-6 d-flex flex-column gap-3 h-100">
+                    <div class="col-12 col-md-6 d-flex flex-column gap-3 col-scan-responsive">
                         <!-- Targets Card (Auto Height) -->
                         <div class="card shadow-sm border-0 d-flex flex-column"
                             style="background: var(--card-bg); flex-shrink: 0;">
@@ -168,7 +143,9 @@
                                 <button class="btn btn-sm btn-dark" id="openImportModalBtn"><i class="bi bi-cloud-arrow-up"></i>
                                     Importar</button>
                             </div>
-                            <div class="card-body d-flex flex-column overflow-hidden">
+                            <div class="card-body d-flex flex-column">
+                                <!-- Alert area for scan feedback (replaces window.alert) -->
+                                <div id="scanAlert" class="mb-2" style="display:none;"></div>
                                 <div class="row g-2 flex-grow-1">
                                     <div class="col-md-6 d-flex flex-column">
                                         <label class="form-label text-light small">IPs de APs (Una por línea)</label>
@@ -212,6 +189,13 @@
 
                         <!-- Quadrant 4: Results / Status / Welcome (Bottom Right) -->
                         <div class="flex-fill position-relative d-flex flex-column" style="min-height: 0;">
+                            <!-- Empty State (shown when no scan is running or completed) -->
+                            <div id="emptyState" class="card shadow-lg border-0 w-100 h-100 d-flex flex-column align-items-center justify-content-center text-center"
+                                style="background: var(--card-bg);">
+                                <i class="bi bi-broadcast" style="font-size: 3.5rem; color: var(--accent-color); opacity: 0.5;"></i>
+                                <h5 class="mt-3 text-light">Listo para analizar</h5>
+                                <p class="text-muted small mb-0">Completa el formulario y presiona <strong>Iniciar Análisis</strong>.</p>
+                            </div>
                             <!-- Status Panel -->
                             <div id="statusPanel" class="card shadow-lg border-0 w-100 h-100"
                                 style="background: var(--card-bg); display: none;">
@@ -504,57 +488,6 @@
         </footer>
     </div>
 
-    <!-- Spectrum Viewer Modal -->
-    <div class="modal fade" id="spectrumModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-xl">
-            <div class="modal-content bg-dark text-white">
-                <div class="modal-header border-secondary">
-                    <h5 class="modal-title"><i class="bi bi-graph-up"></i> Visualizador de Espectro - <span
-                            id="spectrumModalTitle">AP</span></h5>
-                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
-                        aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <canvas id="spectrumChart" style="max-height: 500px;"></canvas>
-                </div>
-                <div class="modal-footer border-secondary">
-                    <small class="text-muted me-auto">Datos en tiempo real obtenidos del radio AP.</small>
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Recommendations Text Modal -->
-    <div class="modal fade" id="textRecommendationsModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-lg">
-            <div class="modal-content bg-dark text-white">
-                <div class="modal-header border-secondary">
-                    <h5 class="modal-title"><i class="bi bi-clipboard-check"></i> Guía de Configuración</h5>
-                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
-                        aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <div id="textRecommendationsContent" class="p-3"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div id="workOrderModal" class="modal work-order-modal">
-        <div class="modal-content wo-content">
-            <div class="wo-header">
-                <h2>Orden de Trabajo</h2>
-                <span class="wo-id" id="woIdDisplay">WO-PING</span>
-            </div>
-            <div id="workOrderContent" class="wo-body"></div>
-            <div class="wo-footer">
-                <button id="acknowledgeBtn" class="btn btn-success w-100">CONFIRMAR (ACK)</button>
-                <button id="closeWoBtn" class="btn btn-secondary mt-2">Cerrar</button>
-            </div>
-        </div>
-    </div>
-
     <!-- CMMAESTRO IMPORT MODAL -->
     <div id="importModal" class="modal">
         <div class="modal-content" style="max-width: 600px;">
@@ -604,8 +537,7 @@
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="{{ url_for('static', filename='js/app.js') }}?v=12"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}?v=13"></script>
     <script src="{{ url_for('static', filename='js/towers.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/users.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/history.js') }}?v=1"></script>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,7 @@
 /* Reset y Variables */
 :root {
     --primary-color: #2196F3;
+    --accent-color: #2196F3;
     --secondary-color: #4CAF50;
     --danger-color: #f44336;
     --warning-color: #ff9800;
@@ -173,7 +174,16 @@ input[type="file"]::-webkit-file-upload-button {
     margin-top: 20px;
 }
 
-.btn {
+/* Button group layout helper (non-Bootstrap) */
+.button-group {
+    display: flex;
+    gap: 15px;
+    flex-wrap: wrap;
+    margin-top: 20px;
+}
+
+/* Custom button overrides — only for legacy .btn elements NOT using Bootstrap btn-* */
+.btn-legacy {
     padding: 12px 24px;
     border: none;
     border-radius: 8px;
@@ -184,36 +194,36 @@ input[type="file"]::-webkit-file-upload-button {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
-.btn:hover {
+.btn-legacy:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
-.btn:active {
+.btn-legacy:active {
     transform: translateY(0);
 }
 
-.btn-primary {
+.btn-legacy-primary {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
 }
 
-.btn-secondary {
+.btn-legacy-secondary {
     background: #555;
     color: white;
 }
 
-.btn-success {
+.btn-legacy-success {
     background: var(--success-color);
     color: white;
 }
 
-.btn-info {
+.btn-legacy-info {
     background: var(--primary-color);
     color: white;
 }
 
-.btn:disabled {
+.btn-legacy:disabled {
     opacity: 0.5;
     cursor: not-allowed;
 }
@@ -523,8 +533,8 @@ details summary:hover {
     color: var(--text-muted);
 }
 
-/* Modal */
-.modal {
+/* Import Modal — custom non-Bootstrap modal used by #importModal */
+#importModal.modal {
     display: none;
     position: fixed;
     z-index: 1000;
@@ -536,7 +546,7 @@ details summary:hover {
     background-color: rgba(0, 0, 0, 0.8);
 }
 
-.modal-content {
+#importModal .modal-content {
     background: var(--card-bg);
     margin: 5% auto;
     padding: 30px;
@@ -632,11 +642,7 @@ details summary:hover {
     .button-group {
         flex-direction: column;
     }
-    
-    .btn {
-        width: 100%;
-    }
-    
+
     .status-info {
         flex-direction: column;
         align-items: flex-start;
@@ -653,10 +659,102 @@ details summary:hover {
     }
 }
 
-/* Issue #6 — Log de Ejecución: evitar colapso en layouts flex vh-100 */
-#logOutput {
-    min-height: 120px;
-    flex-shrink: 0;
+/* ============================================================
+   RESPONSIVE LAYOUT — change-006
+   Strategy: desktop keeps fixed-height flex layout (vh-100);
+   tablet/mobile switches to natural scroll flow.
+   ============================================================ */
+
+/* Desktop: full-height fixed layout */
+@media (min-width: 768px) {
+    .main-container {
+        height: 100vh;
+        overflow: hidden;
+    }
+
+    .tab-content-responsive {
+        min-height: 0;
+        overflow: hidden;
+    }
+
+    .panel-scan-responsive {
+        height: 100%;
+    }
+
+    .scan-row-responsive {
+        height: 100%;
+    }
+
+    .col-scan-responsive {
+        height: 100%;
+    }
+}
+
+/* Mobile / tablet: natural scroll, no height constraints */
+@media (max-width: 767.98px) {
+    .main-container {
+        min-height: 100vh;
+        overflow: visible;
+    }
+
+    .tab-content-responsive {
+        overflow: visible;
+    }
+
+    .panel-scan-responsive,
+    .scan-row-responsive,
+    .col-scan-responsive {
+        height: auto !important;
+        min-height: 0;
+    }
+
+    /* Textareas: allow resize on mobile */
+    #apIPs,
+    #smIPs {
+        min-height: 120px !important;
+        resize: vertical !important;
+    }
+
+    /* Tables: horizontal scroll on small screens */
+    .table-responsive-mobile {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    /* Results/status panels: auto height on mobile */
+    #statusPanel,
+    #resultsPanel,
+    #emptyState {
+        height: auto !important;
+        min-height: 300px;
+    }
+
+    /* Log output: smaller on mobile */
+    #logOutput {
+        max-height: 200px;
+        min-height: 80px;
+    }
+
+    /* Header adjustments */
+    .header {
+        padding: 10px 15px !important;
+    }
+
+    .header h1 {
+        font-size: 1.4rem;
+    }
+}
+
+/* Wrap all tables in results in horizontal scroll */
+#frequencyRecommendations table,
+#resultsSummary table,
+#installationSheetContent table,
+.sm-details-table {
+    min-width: 400px;
+}
+
+.card-body .tab-content {
+    overflow-x: auto;
 }
 
 /* Scrollbar */
@@ -734,25 +832,18 @@ details summary:hover {
     opacity: 0.7;
 }
 
-.badge {
-    display: inline-block;
-    padding: 4px 10px;
-    border-radius: 12px;
-    font-size: 0.85rem;
-    font-weight: bold;
-}
-
+/* Custom badge colors — complement Bootstrap .badge */
 .badge-success {
-    background: var(--success-color);
-    color: #fff;
+    background-color: var(--success-color) !important;
+    color: #fff !important;
 }
 
 .badge-danger {
-    background: var(--danger-color);
-    color: #fff;
+    background-color: var(--danger-color) !important;
+    color: #fff !important;
 }
 
 .badge-warning {
-    background: var(--warning-color);
-    color: #fff;
+    background-color: var(--warning-color) !important;
+    color: #fff !important;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -8,16 +8,11 @@ const appState = {
     currentScanId: null,
     pollInterval: null,
     scanResults: null,
-    chartInstance: null,
     lastLogCount: 0
 };
 
 // Referencias a elementos DOM
 let elements = {};
-
-// Modals
-let spectrumModal = null;
-let textRecommendationsModal = null;
 
 // ==================== INICIALIZACIÓN ====================
 
@@ -52,7 +47,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Dashboard
         welcomeMessage: document.getElementById('welcomeMessage'),
-        spectrumChartCanvas: document.getElementById('spectrumChart'),
 
         // Import Modal
         openImportBtn: document.getElementById('openImportModalBtn'),
@@ -71,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Panels
         statusPanel: document.getElementById('statusPanel'),
         resultsPanel: document.getElementById('resultsPanel'),
-        welcomePanel: document.getElementById('welcomePanel'),
+        emptyState: document.getElementById('emptyState'),
 
         // Status
         statusBadge: document.getElementById('statusBadge'),
@@ -89,17 +83,6 @@ document.addEventListener('DOMContentLoaded', () => {
         // Recent Scans
         recentScans: document.getElementById('recentScans')
     };
-
-    // Inicializar Modales Bootstrap
-    try {
-        const specModalEl = document.getElementById('spectrumModal');
-        if (specModalEl) spectrumModal = new bootstrap.Modal(specModalEl);
-
-        const recModalEl = document.getElementById('textRecommendationsModal');
-        if (recModalEl) textRecommendationsModal = new bootstrap.Modal(recModalEl);
-    } catch (e) {
-        console.warn("Bootstrap modals not initialized (might be missing in HTML yet)", e);
-    }
 
     // Configurar event listeners
     setupEventListeners();
@@ -190,13 +173,6 @@ function setupEventListeners() {
 
     // Close modals on outside click
     window.onclick = function (event) {
-        // Assuming recommendationsModal and workOrderModal are defined elsewhere or will be added
-        // if (event.target == elements.recommendationsModal) {
-        //     elements.recommendationsModal.style.display = "none";
-        // }
-        // if (event.target == elements.workOrderModal) {
-        //      elements.workOrderModal.style.display = "none";
-        // }
         if (elements.importModal && event.target == elements.importModal) {
             elements.importModal.style.display = "none";
         }
@@ -216,13 +192,13 @@ function setupFileUpload(fileInput, targetTextarea, type) {
             if (ips.length > 0) {
                 const current = targetTextarea.value.trim();
                 targetTextarea.value = current ? current + '\n' + ips.join('\n') : ips.join('\n');
-                alert(`Se cargaron ${ips.length} IPs de ${type} correctamente.`);
+                showPanelAlert('scanAlert', `Se cargaron ${ips.length} IPs de ${type} correctamente.`, 'success');
             } else {
-                alert('No se encontraron IPs válidas en el archivo.');
+                showPanelAlert('scanAlert', 'No se encontraron IPs válidas en el archivo.', 'warning');
             }
             fileInput.value = ''; // Reset
         } catch (error) {
-            alert(`Error leyendo archivo: ${error.message}`);
+            showPanelAlert('scanAlert', `Error leyendo archivo: ${error.message}`, 'danger');
         }
     });
 }
@@ -246,14 +222,14 @@ async function startScan() {
     const smIPs = parseIPList(elements.smIPs.value);
 
     if (apIPs.length === 0) {
-        alert('Debe ingresar al menos una IP de Access Point.');
+        showPanelAlert('scanAlert', 'Debe ingresar al menos una IP de Access Point.', 'warning');
         return;
     }
 
     // Validate ticket_id
     const ticketId = elements.ticketId ? parseInt(elements.ticketId.value) : null;
     if (!ticketId || ticketId <= 0) {
-        alert('Debe ingresar un Ticket ID valido (numero entero positivo).');
+        showPanelAlert('scanAlert', 'Debe ingresar un Ticket ID válido (número entero positivo).', 'warning');
         return;
     }
 
@@ -270,7 +246,7 @@ async function startScan() {
     };
 
     // UI Updates
-    if (elements.welcomePanel) elements.welcomePanel.style.display = 'none';
+    if (elements.emptyState) elements.emptyState.style.display = 'none';
     if (elements.resultsPanel) elements.resultsPanel.style.display = 'none';
     if (elements.statusPanel) elements.statusPanel.style.display = 'block';
 
@@ -296,8 +272,6 @@ async function startScan() {
         if (elements.scanIdDisplay) elements.scanIdDisplay.textContent = result.scan_id;
 
         addLogEntry(`Scan ID: ${result.scan_id}`, 'success');
-        addLogEntry(`Objetivo: ${result.ap_count} APs, ${result.sm_count || 0} SMs`, 'info');
-
         addLogEntry(`Objetivo: ${result.ap_count} APs, ${result.sm_count || 0} SMs`, 'info');
 
         appState.lastLogCount = 0; // Reset log counter
@@ -702,11 +676,10 @@ function openSpectrumViewer(ip) {
     console.log("Abriendo visualizador para", ip);
 
     if (!appState.currentScanId) {
-        // Intentar recuperar ID del resultado si no está en estado global
         if (appState.scanResults && appState.scanResults.scan_id) {
             appState.currentScanId = appState.scanResults.scan_id;
         } else {
-            alert("No se puede identificar el ID del escaneo. Por favor inicie un nuevo escaneo.");
+            showPanelAlert('scanAlert', 'No se puede identificar el ID del escaneo. Por favor inicie un nuevo escaneo.', 'warning');
             return;
         }
     }
@@ -717,18 +690,16 @@ function openSpectrumViewer(ip) {
 
 function openGlobalSpectrumViewer() {
     if (!appState.scanResults || !appState.scanResults.analysis_results) {
-        alert("No hay resultados de análisis disponibles.");
+        showPanelAlert('scanAlert', 'No hay resultados de análisis disponibles.', 'warning');
         return;
     }
 
-    // Buscar la primer IP de AP disponible
     const ips = Object.keys(appState.scanResults.analysis_results);
     if (ips.length === 0) {
-        alert("No se encontraron APs en los resultados.");
+        showPanelAlert('scanAlert', 'No se encontraron APs en los resultados.', 'warning');
         return;
     }
 
-    // Abrir el primero (o podría implementarse un selector si se desea)
     openSpectrumViewer(ips[0]);
 }
 
@@ -772,15 +743,14 @@ function resetInterface() {
         clearInterval(appState.pollInterval);
         appState.pollInterval = null;
     }
-    // Reset all application state (Issue #5)
+    // Reset all application state
     appState.currentScanId = null;
     appState.scanResults = null;
     appState.lastLogCount = 0;
-    // chartInstance is kept — it will be replaced on next displayResults()
 
-    elements.resultsPanel.style.display = 'none';
-    elements.statusPanel.style.display = 'none';
-    elements.welcomePanel.style.display = 'block';
+    if (elements.resultsPanel) elements.resultsPanel.style.display = 'none';
+    if (elements.statusPanel) elements.statusPanel.style.display = 'none';
+    if (elements.emptyState) elements.emptyState.style.display = 'flex';
     clearForm();
 }
 
@@ -873,7 +843,7 @@ async function loadRecentScans() {
 
                     if (status.status === 'completed' && status.results) {
                         appState.currentScanId = scanId;
-                        if (elements.welcomePanel) elements.welcomePanel.style.display = 'none';
+                        if (elements.emptyState) elements.emptyState.style.display = 'none';
                         if (elements.statusPanel) elements.statusPanel.style.display = 'none';
                         displayResults(status.results);
                     }
@@ -908,17 +878,16 @@ async function openImportModal() {
     if (!elements.importModal) return;
     elements.importModal.style.display = 'block';
 
-    // Reset view
     if (elements.stepLoading) elements.stepLoading.style.display = 'block';
     if (elements.stepSelection) elements.stepSelection.style.display = 'none';
 
     try {
         const response = await authFetch('/api/cnmaestro/inventory');
-        if (!response) return; // Redirected to login
+        if (!response) return;
         const data = await response.json();
 
         if (data.error) {
-            alert('Error cargando inventario: ' + data.error);
+            showPanelAlert('scanAlert', 'Error cargando inventario: ' + data.error, 'danger');
             elements.importModal.style.display = 'none';
             return;
         }
@@ -930,7 +899,7 @@ async function openImportModal() {
         if (elements.stepSelection) elements.stepSelection.style.display = 'block';
 
     } catch (e) {
-        alert('Error conectando con el servidor: ' + e);
+        showPanelAlert('scanAlert', 'Error conectando con el servidor: ' + e, 'danger');
         elements.importModal.style.display = 'none';
     }
 }

--- a/tests/test_frontend_buttons.py
+++ b/tests/test_frontend_buttons.py
@@ -1,0 +1,146 @@
+"""
+tests/test_frontend_buttons.py — T55: Frontend Button Functionality Tests (change-006).
+
+Specification: change-006 — verify that the main index page renders critical
+button IDs, the emptyState panel, and that vestige elements are absent.
+
+Scenarios:
+  1.  GET / renders 200 for authenticated user
+  2.  startScanBtn is present
+  3.  clearBtn is present
+  4.  newScanBtn is present
+  5.  exportResultsBtn is present
+  6.  openImportModalBtn is present
+  7.  globalSpectrumBtn is present
+  8.  #emptyState panel is present (bug fix: was welcomePanel → null crash)
+  9.  #statusPanel is present
+  10. #resultsPanel is present
+  11. VESTIGE ABSENT: #workOrderModal removed
+  12. VESTIGE ABSENT: #spectrumModal removed
+  13. VESTIGE ABSENT: #textRecommendationsModal removed
+  14. VESTIGE ABSENT: decorative #prioritizeUplink checkbox removed
+  15. VESTIGE ABSENT: decorative #stabilityOverSpeed checkbox removed
+  16. VESTIGE ABSENT: chart.js CDN script tag removed (not used in index)
+  17. #scanAlert feedback div is present
+  18. Import modal (#importModal) is present
+  19. Log output (#logOutput) is present
+  20. snmpCommunity input is present
+"""
+
+import pytest
+
+
+class TestIndexPageRendering:
+    """GET / — base page renders correctly for authenticated user."""
+
+    def test_index_returns_200(self, authenticated_client):
+        """GIVEN authenticated user WHEN GET / THEN 200."""
+        response = authenticated_client.get("/")
+        assert response.status_code == 200
+
+    def test_index_contains_html(self, authenticated_client):
+        """GIVEN GET / THEN response is HTML with <body>."""
+        response = authenticated_client.get("/")
+        html = response.data.decode("utf-8")
+        assert "<body" in html
+
+
+class TestCriticalButtonsPresent:
+    """Verify all critical action button IDs are rendered in the index page."""
+
+    def _html(self, authenticated_client):
+        return authenticated_client.get("/").data.decode("utf-8")
+
+    def test_start_scan_btn_present(self, authenticated_client):
+        """GIVEN GET / THEN #startScanBtn button exists in HTML."""
+        assert 'id="startScanBtn"' in self._html(authenticated_client)
+
+    def test_clear_btn_present(self, authenticated_client):
+        """GIVEN GET / THEN #clearBtn button exists in HTML."""
+        assert 'id="clearBtn"' in self._html(authenticated_client)
+
+    def test_new_scan_btn_present(self, authenticated_client):
+        """GIVEN GET / THEN #newScanBtn button exists in HTML (Nuevo)."""
+        assert 'id="newScanBtn"' in self._html(authenticated_client)
+
+    def test_export_results_btn_present(self, authenticated_client):
+        """GIVEN GET / THEN #exportResultsBtn button exists in HTML."""
+        assert 'id="exportResultsBtn"' in self._html(authenticated_client)
+
+    def test_open_import_modal_btn_present(self, authenticated_client):
+        """GIVEN GET / THEN #openImportModalBtn button exists in HTML."""
+        assert 'id="openImportModalBtn"' in self._html(authenticated_client)
+
+    def test_global_spectrum_btn_present(self, authenticated_client):
+        """GIVEN GET / THEN #globalSpectrumBtn button exists in HTML."""
+        assert 'id="globalSpectrumBtn"' in self._html(authenticated_client)
+
+
+class TestCriticalPanelsPresent:
+    """Verify all critical UI panels are rendered."""
+
+    def _html(self, authenticated_client):
+        return authenticated_client.get("/").data.decode("utf-8")
+
+    def test_empty_state_panel_present(self, authenticated_client):
+        """GIVEN GET / THEN #emptyState div exists (fix: was welcomePanel → null crash)."""
+        assert 'id="emptyState"' in self._html(authenticated_client)
+
+    def test_status_panel_present(self, authenticated_client):
+        """GIVEN GET / THEN #statusPanel div exists."""
+        assert 'id="statusPanel"' in self._html(authenticated_client)
+
+    def test_results_panel_present(self, authenticated_client):
+        """GIVEN GET / THEN #resultsPanel div exists."""
+        assert 'id="resultsPanel"' in self._html(authenticated_client)
+
+    def test_scan_alert_div_present(self, authenticated_client):
+        """GIVEN GET / THEN #scanAlert inline feedback div exists."""
+        assert 'id="scanAlert"' in self._html(authenticated_client)
+
+    def test_log_output_present(self, authenticated_client):
+        """GIVEN GET / THEN #logOutput div exists."""
+        assert 'id="logOutput"' in self._html(authenticated_client)
+
+    def test_import_modal_present(self, authenticated_client):
+        """GIVEN GET / THEN #importModal exists."""
+        assert 'id="importModal"' in self._html(authenticated_client)
+
+    def test_snmp_community_input_present(self, authenticated_client):
+        """GIVEN GET / THEN #snmpCommunity input exists."""
+        assert 'id="snmpCommunity"' in self._html(authenticated_client)
+
+
+class TestVestigeElementsAbsent:
+    """Verify all dead/vestige elements are removed from the index page (change-006)."""
+
+    def _html(self, authenticated_client):
+        return authenticated_client.get("/").data.decode("utf-8")
+
+    def test_work_order_modal_removed(self, authenticated_client):
+        """GIVEN GET / THEN #workOrderModal vestige is NOT in HTML."""
+        assert 'id="workOrderModal"' not in self._html(authenticated_client)
+
+    def test_spectrum_modal_removed(self, authenticated_client):
+        """GIVEN GET / THEN #spectrumModal vestige is NOT in HTML."""
+        assert 'id="spectrumModal"' not in self._html(authenticated_client)
+
+    def test_text_recommendations_modal_removed(self, authenticated_client):
+        """GIVEN GET / THEN #textRecommendationsModal vestige is NOT in HTML."""
+        assert 'id="textRecommendationsModal"' not in self._html(authenticated_client)
+
+    def test_prioritize_uplink_checkbox_removed(self, authenticated_client):
+        """GIVEN GET / THEN decorative #prioritizeUplink checkbox is NOT in HTML."""
+        assert 'id="prioritizeUplink"' not in self._html(authenticated_client)
+
+    def test_stability_over_speed_checkbox_removed(self, authenticated_client):
+        """GIVEN GET / THEN decorative #stabilityOverSpeed checkbox is NOT in HTML."""
+        assert 'id="stabilityOverSpeed"' not in self._html(authenticated_client)
+
+    def test_chartjs_cdn_removed(self, authenticated_client):
+        """GIVEN GET / THEN unused chart.js CDN script tag is NOT in HTML."""
+        assert "cdn.jsdelivr.net/npm/chart.js" not in self._html(authenticated_client)
+
+    def test_acknowledge_btn_removed(self, authenticated_client):
+        """GIVEN GET / THEN dead #acknowledgeBtn (workOrderModal) is NOT in HTML."""
+        assert 'id="acknowledgeBtn"' not in self._html(authenticated_client)


### PR DESCRIPTION
- Fix resetInterface() crash: replace null welcomePanel with emptyState panel
- Remove all vestige/dead HTML: workOrderModal, spectrumModal, textRecommendationsModal, decorative checkboxes, chart.js CDN
- Add #emptyState panel with friendly empty state message
- Replace all native alert() with inline showPanelAlert() feedback
- Responsive layout: replace vh-100+overflow:hidden with CSS breakpoints
- Mobile-friendly: natural scroll on <768px, textareas resizable, tables scrollable
- CSS cleanup: scope .modal/.btn/.badge to avoid Bootstrap 5 conflicts
- Add 22 pytest tests covering button presence and vestige absence (T55)