### PR TITLE
fix+feat(frontend): AP_ONLY pool fix + apply button in AP_ONLY mode

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -658,6 +658,23 @@ function renderAPCard(ip, analysis) {
                 <small>Score: ${best['Puntaje Final']} | SNR Est: ${best['SNR Estimado (dB)']} dB</small>
             </div>
         `;
+
+        // Botón apply para modo AP_ONLY — mismo flujo que AP_SM_CROSS
+        if (!isViewer) {
+            const scanId = appState.currentScanId || (appState.scanResults && appState.scanResults.scan_id);
+            if (scanId && best['Frecuencia Central (MHz)']) {
+                // Normalizar score a 0-1 (Puntaje Final es int, max teórico ~200)
+                const scoreNorm = ((best['Puntaje Final'] || 0) / 200).toFixed(2);
+                const isViableAP = best['Válido'] === 'Sí';
+                applyBtn = `
+                    <button type="button" class="btn btn-warning btn-sm ms-2"
+                        id="applyBtn-${ip.replace(/\./g, '-')}"
+                        onclick="openApplyModal('${escapeAttr(scanId)}', '${escapeAttr(ip)}', ${best['Frecuencia Central (MHz)']}, ${scoreNorm}, ${isViableAP})"
+                        title="Aplicar frecuencia óptima vía SNMP">
+                        <i class="bi bi-lightning-charge-fill"></i> Aplicar Frec.
+                    </button>`;
+            }
+        }
     } else {
         bestFreqInfo = '<div class="alert alert-warning">No se encontraron frecuencias válidas.</div>';
     }


### PR DESCRIPTION
## Cambios incluidos

### fix: Pool de Frecuencias con undefined en modo AP_ONLY (Closes #18)
Mismatch de keys entre backend AP_ONLY y frontend en `renderInstallationSheet()`.
Dual-key fallback con `??` para cubrir ambos modos (AP_ONLY y AP_SM_CROSS).

### feat: Boton Aplicar Frec. disponible en scans AP_ONLY
Previamente el boton solo aparecia en modo AP_SM_CROSS.
Ahora usa las keys correctas de `best_frequency` (AP_ONLY):
- `Frecuencia Central (MHz)` en lugar de `frequency`
- `Valido` = 'Si' en lugar de `Estado` = 'Viable'
- `Puntaje Final` normalizado a 0-1 para el modal

**Sin cambios en backend ni en tests de pytest.**