### PR TITLE
fix: 3 bugs in apply-frequency modal (freq range + AP_ONLY gate + tower FK)

### DIFF
--- a/app/db_manager.py
+++ b/app/db_manager.py
@@ -339,6 +339,9 @@ CREATE INDEX IF NOT EXISTS idx_freq_applies_status ON frequency_applies(state);
         Returns:
             The new row ID (integer).
         """
+        # Normalize tower_id: empty string → None (FK allows NULL via ON DELETE SET NULL)
+        tower_id_val = tower_id if tower_id and tower_id.strip() else None
+
         conn = self.get_connection()
         try:
             cursor = conn.execute(
@@ -347,7 +350,7 @@ CREATE INDEX IF NOT EXISTS idx_freq_applies_status ON frequency_applies(state);
                     freq_khz, prev_freq_khz, channel_width, state)
                    VALUES (?, ?, ?, ?, ?, ?, ?, 'pending')""",
                 (
-                    tower_id,
+                    tower_id_val,
                     scan_id,
                     applied_by,
                     applied_by_username,

--- a/app/freq_apply_manager.py
+++ b/app/freq_apply_manager.py
@@ -100,18 +100,43 @@ class FrequencyApplyManager:
         # 2. Viability gate (unless force=True)
         if not force:
             results = scan.get("results") or {}
-            best = results.get("best_combined_frequency") or {}
-            is_viable = best.get("is_viable", False)
-            combined_score = best.get("combined_score", 0.0)
 
-            if not is_viable:
+            # AP_SM_CROSS mode: combined score + is_viable
+            best_combined = results.get("best_combined_frequency") or {}
+
+            # AP_ONLY mode: per-AP best_frequency inside analysis_results
+            # Pick the first AP's best_frequency as the gate signal
+            best_ap = {}
+            analysis_results = results.get("analysis_results") or {}
+            for ap_data in analysis_results.values():
+                if isinstance(ap_data, dict) and ap_data.get("best_frequency"):
+                    best_ap = ap_data["best_frequency"]
+                    break
+
+            if best_combined:
+                # AP_SM_CROSS path
+                is_viable = best_combined.get("is_viable", False)
+                combined_score = best_combined.get("combined_score", 0.0)
+                if not is_viable:
+                    raise ValueError(
+                        "Analysis not viable. Use force=true to override."
+                    )
+                if combined_score < _VIABILITY_SCORE_THRESHOLD:
+                    raise ValueError(
+                        f"combined_score {combined_score:.2f} is below threshold "
+                        f"{_VIABILITY_SCORE_THRESHOLD}. Use force=true to override."
+                    )
+            elif best_ap:
+                # AP_ONLY path — 'Válido'='Sí' is the viability signal
+                is_viable_ap = best_ap.get("Válido") == "Sí" or best_ap.get("is_optimal", False)
+                if not is_viable_ap:
+                    raise ValueError(
+                        "Analysis not viable (AP_ONLY). Use force=true to override."
+                    )
+            else:
+                # No analysis results at all — block unless force
                 raise ValueError(
-                    "Analysis not viable. Use force=true to override."
-                )
-            if combined_score < _VIABILITY_SCORE_THRESHOLD:
-                raise ValueError(
-                    f"combined_score {combined_score:.2f} is below threshold "
-                    f"{_VIABILITY_SCORE_THRESHOLD}. Use force=true to override."
+                    "No analysis results found in scan. Use force=true to override."
                 )
 
         # 3. Extract SM IPs from scan record

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1181,7 +1181,7 @@ function _ensureApplyModal() {
             <div id="applyModalBadges" style="margin-bottom:1rem;display:flex;gap:.5rem;flex-wrap:wrap;"></div>
             <div style="margin-bottom:.75rem;">
                 <label for="applyInputFreq" style="font-size:.85rem;color:#aaa;">Frecuencia (MHz)</label>
-                <input type="number" id="applyInputFreq" step="0.5" min="4900" max="6000"
+                <input type="number" id="applyInputFreq" step="0.5" min="3400" max="6000"
                     style="width:100%;padding:.4rem .7rem;background:#2a2a3e;border:1px solid #555;border-radius:6px;color:#fff;font-size:1rem;">
             </div>
             <div style="margin-bottom:.75rem;">
@@ -1274,8 +1274,8 @@ async function submitApplyFrequency() {
     if (_applyModal.submitting) return;
 
     const freqMhz = parseFloat(document.getElementById('applyInputFreq').value);
-    if (!freqMhz || freqMhz < 4900 || freqMhz > 6000) {
-        showApplyResult('danger', 'Frecuencia invalida. Debe estar entre 4900 y 6000 MHz.');
+    if (!freqMhz || freqMhz < 3400 || freqMhz > 6000) {
+        showApplyResult('danger', 'Frecuencia invalida. Debe estar entre 3400 y 6000 MHz.');
         return;
     }
 


### PR DESCRIPTION
## Bugs corregidos

### Bug 1 - Rango de frecuencia demasiado restrictivo
Amplia validacion de 4900-6000 a 3400-6000 MHz. El PMP 450i soporta banda de 4 GHz (~4080 MHz).

### Bug 2 - Viability gate no soportaba modo AP_ONLY
El gate solo leia `best_combined_frequency` (AP_SM_CROSS). En AP_ONLY ese key no existe -> `is_viable=False` siempre. Ahora detecta ambos modos.

### Bug 3 - 500 Internal Server Error con force=True
`tower_id` vacio causaba violacion de FK en `frequency_applies`. Normaliza string vacio a NULL (columna es ON DELETE SET NULL).