### PR TITLE
feat(change-007): enhanced apply - dropdown, channel width, contention slots, broadcast retry + reboot

### DIFF
--- a/app/freq_apply_manager.py
+++ b/app/freq_apply_manager.py
@@ -267,6 +267,16 @@ class FrequencyApplyManager:
             errors.append(f"broadcast_retry {ap_ip}: {br_msg}")
             logger.warning("[APPLY %d] broadcast_retry SET falló (non-fatal): %s", apply_id, br_msg)
 
+        # ── Step 4e: rebootIfRequired = 1 (SIEMPRE, último paso) ──────────
+        # El equipo evaluará si los cambios requieren reinicio y lo ejecutará
+        # automáticamente. El AP quedará inaccesible ~30-60 s (esperado).
+        rb_success, rb_msg = self._scanner.reboot_if_required(ap_ip)
+        if rb_success:
+            logger.info("[APPLY %d] AP %s: rebootIfRequired=1 enviado OK", apply_id, ap_ip)
+        else:
+            errors.append(f"reboot {ap_ip}: {rb_msg}")
+            logger.warning("[APPLY %d] reboot_if_required SET falló (non-fatal): %s", apply_id, rb_msg)
+
         # ── Step 5: Determine final state ─────────────────────────────────
         # State machine rules (from spec Domain 8):
         #   AP fails → failed (regardless of SMs)
@@ -313,6 +323,7 @@ class FrequencyApplyManager:
             "channel_width_result": channel_width_result,
             "contention_slots_ok": ct_success,
             "broadcast_retry_ok": br_success,
+            "reboot_ok": rb_success,
             "sm_results": sm_results,
             "ap_result": ap_result,
             "errors": errors,

--- a/app/tower_scan.py
+++ b/app/tower_scan.py
@@ -986,9 +986,54 @@ class TowerScanner:
             self._log(f"[APPLY] {ip}: Excepción set_broadcast_retry — {msg}", "error")
             return False, msg
 
-    def run_scan(self) -> Dict[str, Dict]:
+    def reboot_if_required(self, ip: str) -> Tuple[bool, str]:
+        """Trigger conditional reboot on AP via SNMP SET rebootIfRequired.0 = 1.
+
+        OID: .1.3.6.1.4.1.161.19.3.3.3.4.0 (rebootIfRequired.0, Integer)
+        Value: 1 — the device evaluates pending changes and reboots automatically
+                     if any parameter (frequency, channel width, color code, etc.)
+                     requires it.
+
+        MUST be called LAST in the apply sequence, after all other SETs.
+        The AP will become unreachable for ~30-60 s during reboot.
+
+        Args:
+            ip: AP IP address.
+
+        Returns:
+            Tuple (success: bool, message: str).
+            NOTE: Even if SET succeeds, subsequent SNMP to this IP will time out
+            while the device reboots — this is expected behaviour.
         """
-        Ejecutar Tower Scan (wrapper síncrono)
+        REBOOT_OID = "1.3.6.1.4.1.161.19.3.3.3.4.0"  # rebootIfRequired.0
+        VALUE = 1
+
+        self._log(f"[APPLY] {ip}: SET rebootIfRequired = {VALUE} (reinicio condicional)", "info")
+        try:
+            iterator = setCmd(
+                SnmpEngine(),
+                CommunityData(self.write_community, mpModel=1),
+                UdpTransportTarget((ip, 161), timeout=self.SNMP_TIMEOUT, retries=self.SNMP_RETRIES),
+                ContextData(),
+                ObjectType(ObjectIdentity(REBOOT_OID), Integer32(VALUE)),
+            )
+            errInd, errStat, _, _ = next(iterator)
+            if not errInd and not errStat:
+                self._log(
+                    f"[APPLY] {ip}: rebootIfRequired=1 enviado — el equipo reiniciará si es necesario",
+                    "info",
+                )
+                return True, "Reboot iniciado"
+            msg = f"SNMP Error: {errInd or errStat.prettyPrint()}"
+            self._log(f"[APPLY] {ip}: FALLÓ reboot_if_required — {msg}", "error")
+            return False, msg
+        except Exception as e:
+            msg = str(e)
+            self._log(f"[APPLY] {ip}: Excepción reboot_if_required — {msg}", "error")
+            return False, msg
+
+    def run_scan(self) -> Dict[str, Dict]:
+        """Ejecutar Tower Scan (wrapper síncrono).
 
         Returns:
             Diccionario con resultados por IP

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1419,12 +1419,16 @@ async function submitApplyFrequency() {
             const extraOk = [
                 data.contention_slots_ok !== false ? '✓ CS=4' : '⚠ CS',
                 data.broadcast_retry_ok !== false ? '✓ BR=0' : '⚠ BR',
-            ].join(' ');
+                data.reboot_ok !== false ? '✓ Reboot' : '⚠ Reboot',
+            ].join(' &nbsp;');
 
             if (state === 'completed') {
                 let detail = `Frecuencia <strong>${freqResult} MHz${bwResult}</strong> aplicada correctamente`;
                 if (smErrors.length > 0) detail += `<br><small style="color:#ffc107;"><i class="bi bi-exclamation-triangle"></i> ${smErrors.length} SM(s) con errores — AP OK</small>`;
                 detail += `<br><small style="color:#aaa;">${extraOk}</small>`;
+                if (data.reboot_ok !== false) {
+                    detail += `<br><small style="color:#6edff6;"><i class="bi bi-arrow-clockwise"></i> El equipo está reiniciando (~30-60 s de inactividad)</small>`;
+                }
                 showApplyResult('success', `<i class="bi bi-check-circle-fill"></i> <strong>Completado</strong> (apply_id=${applyId})<br>${detail}`);
             } else {
                 const errMsg = apError || (data.errors || []).join('; ') || 'Error desconocido';


### PR DESCRIPTION
Closes #24

## Cambios

- Modal: dropdown top-20 frecuencias + dropdown ancho canal
- Backend: set_channel_width (3 OID fallback), set_contention_slots=4, set_broadcast_retry=0, reboot_if_required
- Secuencia: SM scan list -> AP freq -> channel_width -> CS=4 -> BR=0 -> reboot
- Resultado muestra BW aplicado + estado CS/BR/Reboot + nota de reinicio en cyan