### PR TITLE
fix(snmp): band-aware channel width mapping - 3GHz vs 4/5GHz

### DIFF
--- a/app/freq_apply_manager.py
+++ b/app/freq_apply_manager.py
@@ -242,7 +242,11 @@ class FrequencyApplyManager:
         # ── Step 4b: SET channel_width (opcional, si se provee) ───────────
         channel_width_result = None
         if channel_width and ap_success:
-            bw_success, bw_msg = self._scanner.set_channel_width(ap_ip, channel_width)
+            # Pasar freq_mhz para detectar banda (3GHz vs 4/5GHz) sin GET extra
+            ap_freq_mhz = freq_khz / 1000.0  # freq_khz ya está en kHz
+            bw_success, bw_msg = self._scanner.set_channel_width(
+                ap_ip, channel_width, ap_freq_mhz=ap_freq_mhz
+            )
             channel_width_result = {"success": bw_success, "error": bw_msg if not bw_success else None}
             if bw_success:
                 logger.info("[APPLY %d] AP %s: channelBandwidth=%d MHz OK", apply_id, ap_ip, channel_width)

--- a/app/tower_scan.py
+++ b/app/tower_scan.py
@@ -836,40 +836,65 @@ class TowerScanner:
 
         return success, msg
 
-    def set_channel_width(self, ip: str, width_mhz: int) -> Tuple[bool, str]:
+    def set_channel_width(self, ip: str, width_mhz: int, ap_freq_mhz: float = None) -> Tuple[bool, str]:
         """SET channel bandwidth on AP via SNMP.
 
         OID priority (confirmed by Cambium MIB field testing):
           1. .1.3.6.1.4.1.161.19.3.3.2.83.0  — channelBandwidth.0 (OctetString, WRITABLE)
-             Format: "5.0 MHz", "10.0 MHz", "20.0 MHz", "30.0 MHz", "40.0 MHz"
-             This is the only OID with a confirmed snmpset example in Cambium docs.
-          2. .1.3.6.1.4.1.161.19.3.3.2.91.0  — bandwidth.0 (Integer, fallback)
-             May be read-only on fw24.x — silently accepts writes but doesn't apply.
-             Integer mapping: 1=5MHz, 2=10MHz, 3=15MHz, 4=20MHz, 5=30MHz, 6=40MHz
+             Format: "5.0 MHz", "7.0 MHz", "10.0 MHz", "20.0 MHz", etc.
+          2. .1.3.6.1.4.1.161.19.3.3.2.91.0  — bandwidth.0 (Integer fallback)
+             3 GHz map: 1=5, 2=7, 3=10, 4=15, 5=20, 6=30, 7=40
+             4/5 GHz map: 1=5, 2=10, 3=15, 4=20, 5=30, 6=40
+
+        IMPORTANT: Integer maps differ between 3 GHz and 4/5 GHz hardware.
+        The 3 GHz enum has an extra '7 MHz' slot at position 2.
+        Pass ap_freq_mhz (from scan results) to avoid GET overhead.
 
         NOTE: OID 221.0 is SPECTRUM_ACTION_OID — do NOT use for channel bandwidth.
 
         Args:
-            ip:        AP IP address.
-            width_mhz: Channel width in MHz (5, 10, 15, 20, 30 or 40).
+            ip:          AP IP address.
+            width_mhz:   Channel width in MHz (5, 7, 10, 15, 20, 30 or 40).
+            ap_freq_mhz: AP operating frequency in MHz to detect band (optional).
+                         If None, a SNMP GET is performed to detect the band.
 
         Returns:
             Tuple (success: bool, message: str).
         """
-        BW_INT_MAP = {5: 1, 10: 2, 15: 3, 20: 4, 30: 5, 40: 6}
-        bw_int = BW_INT_MAP.get(int(width_mhz))
+        # ── Band detection ──────────────────────────────────────────
+        if ap_freq_mhz is None:
+            # Fallback: GET current rfFreqCarrier to detect band
+            ok, raw, _ = self._snmp_get(ip=ip, oid=self.RF_FREQ_CARRIER_OID)
+            try:
+                ap_freq_mhz = int(raw) / 1000.0 if ok and raw else None
+            except (TypeError, ValueError):
+                ap_freq_mhz = None
+
+        # 3 GHz band: 3000–3900 MHz — has 7 MHz as extra slot at position 2
+        is_3ghz = ap_freq_mhz is not None and 3000 <= ap_freq_mhz < 3900
+
+        # ── Integer maps per band ─────────────────────────────────────
+        BW_INT_MAP_3GHZ = {5: 1, 7: 2, 10: 3, 15: 4, 20: 5, 30: 6, 40: 7}
+        BW_INT_MAP_5GHZ = {5: 1, 10: 2, 15: 3, 20: 4, 30: 5, 40: 6}
+        bw_int_map = BW_INT_MAP_3GHZ if is_3ghz else BW_INT_MAP_5GHZ
+        valid_bws = list(bw_int_map.keys())
+
+        bw_int = bw_int_map.get(int(width_mhz))
         if bw_int is None:
-            return False, f"Ancho de canal {width_mhz} MHz no soportado. Válidos: {list(BW_INT_MAP.keys())}"
+            return False, (
+                f"Ancho de canal {width_mhz} MHz no soportado para banda "
+                f"{'3GHz' if is_3ghz else '4/5GHz'}. Válidos: {valid_bws}"
+            )
 
         # OID 1: OctetString — único con SET confirmado por Cambium
         CHANNEL_BW_OID_STR = "1.3.6.1.4.1.161.19.3.3.2.83.0"   # channelBandwidth.0
-        # OID 2: Integer fallback — puede ser read-only en fw24.x
+        # OID 2: Integer fallback — requiere mapa correcto por banda
         CHANNEL_BW_OID_INT = "1.3.6.1.4.1.161.19.3.3.2.91.0"   # bandwidth.0
-        bw_str = f"{float(width_mhz):.1f} MHz"  # → "20.0 MHz", "40.0 MHz", etc.
+        bw_str = f"{float(width_mhz):.1f} MHz"  # → "20.0 MHz", "7.0 MHz", etc.
 
         self._log(
             f"[APPLY] {ip}: SET channelBandwidth = {width_mhz} MHz "
-            f"(str='{bw_str}', int={bw_int})",
+            f"(banda={'3GHz' if is_3ghz else '4/5GHz'} str='{bw_str}' int={bw_int})",
             "info",
         )
 
@@ -886,11 +911,11 @@ class TowerScanner:
             )
             return True, "OK"
         self._log(
-            f"[APPLY] {ip}: OID .83.0 falló ({msg}) — probando Integer .91.0",
+            f"[APPLY] {ip}: OID .83.0 falló ({msg}) — probando Integer .91.0 (banda={'3GHz' if is_3ghz else '4/5GHz'})",
             "warning",
         )
 
-        # Try 2: Integer OID .91.0 (fallback — puede ser read-only en algunos fw)
+        # Try 2: Integer OID .91.0 (fallback) con mapa correcto de banda
         try:
             iterator = setCmd(
                 SnmpEngine(),
@@ -902,11 +927,11 @@ class TowerScanner:
             errInd, errStat, _, _ = next(iterator)
             if not errInd and not errStat:
                 self._log(
-                    f"[APPLY] {ip}: SET channelBandwidth={width_mhz}MHz OK (OID .91.0 int={bw_int}) "
-                    f"[WARNING: this OID may be read-only on fw24.x]",
+                    f"[APPLY] {ip}: SET channelBandwidth={width_mhz}MHz OK "
+                    f"(OID .91.0 int={bw_int} banda={'3GHz' if is_3ghz else '4/5GHz'})",
                     "warning",
                 )
-                return True, "OK (via .91.0 — verify on device)"
+                return True, "OK (via .91.0)"
             msg = f"SNMP Error: {errInd or errStat.prettyPrint()}"
             self._log(f"[APPLY] {ip}: FALLÓ ambos OIDs de channelBandwidth — {msg}", "error")
             return False, msg


### PR DESCRIPTION
3GHz Integer enum has extra 7MHz slot at position 2. Sending int=2 for 10MHz was landing at 7MHz on 3GHz hardware.

Fix: detect band from ap_freq_mhz, select correct int map per band. 7MHz now valid option for 3GHz.