### PR TITLE
fix(css): independent column scroll — SDD change layout-column-scroll

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,7 @@
     <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=14">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=15">
 </head>
 
 <body>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -666,13 +666,15 @@ details summary:hover {
    - Mobile/tablet: natural scroll flow, altura auto en todos los paneles.
    ============================================================ */
 
-/* Desktop: scrollable layout — cada panel gestiona su propio overflow */
+/* Desktop: independent column scroll (Gmail/Slack pattern)
+   main-container contiene el viewport (overflow:hidden)
+   cada .col-scan-responsive scrollea de forma independiente (overflow-y:auto)
+   El header de navegacion siempre queda fijo y visible */
 @media (min-width: 768px) {
     .main-container {
         height: 100vh;
-        /* overflow:auto como safety net — si algo escapa al layout, el viewport scrollea
-           en lugar de cortar silenciosamente el contenido (fix vs. overflow:hidden) */
-        overflow: auto;
+        /* overflow:hidden — el scroll ocurre por columna, NO a nivel de pagina */
+        overflow: hidden;
     }
 
     .tab-content-responsive {
@@ -690,6 +692,8 @@ details summary:hover {
 
     .col-scan-responsive {
         height: 100%;
+        /* Cada columna scrollea independientemente — no afecta a la otra columna */
+        overflow-y: auto;
     }
 
     /* Log panel: altura mínima garantizada en desktop */


### PR DESCRIPTION
## Descripcion

Corrige el fallo donde el contenido de la columna derecha (Objetivos + Resultados) desbordaba el viewport sin scrollbar visible. Identificado durante el verify de `frontend-responsive-ux` y confirmado como bug heredado del layout anterior.

## Root Cause

`.col-scan-responsive` tenia `height: 100%` en desktop pero sin `overflow-y: auto`. El main-container usaba `overflow: auto` como safety net global, produciendo scroll de PAGINA COMPLETA en lugar de scroll por columna. Cuando `#resultsPanel` tenia multiples AP cards, el contenido quedaba inaccesible.

## Cambios

### style.css (2 cambios)

**Cambio 1 — `.main-container` desktop:**
```
overflow: auto → overflow: hidden
```
El main-container ahora contiene el viewport. El scroll ocurre por columna, no a nivel de pagina.

**Cambio 2 — `.col-scan-responsive` desktop:**
```
+ overflow-y: auto
```
Cada columna scrollea de forma independiente. La columna izquierda (Config + Log) y la derecha (Objetivos + Resultados) son viewports independientes.

### index.html
- Cache-bust: `style.css?v=14` → `?v=15`

## Modelo resultante (Gmail/Slack pattern)

```
[Header — siempre visible]
────────────────────────────────────────────
│ Col izquierda (scroll ↕) │ Col derecha (scroll ↕) │
│ Configuracion             │ Objetivos               │
│ Historial Reciente        │ [AP cards en resultados]│
│ Log de Ejecucion ↕        │   (scrollea aqui) ↕    │
────────────────────────────────────────────
```

## Mobile

Sin cambios — el bloque `@media (max-width: 767.98px)` mantiene `overflow: visible` y height auto. No hay regresion.

## Verificacion

- [ ] Desktop: columna derecha con resultados scrollea independientemente
- [ ] Desktop: columna izquierda con log scrollea independientemente
- [ ] Mobile: comportamiento natural sin cambios
- [ ] Auto-scroll del log sigue funcionando
