### PR TITLE
fix(timestamps): unify all datetime to UTC + fix frontend log ts mism…

### DIFF
--- a/app/routes/scan_routes.py
+++ b/app/routes/scan_routes.py
@@ -26,7 +26,7 @@ from functools import wraps
 import asyncio
 import threading
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict
 import logging
 import os
@@ -220,7 +220,7 @@ def start_scan(audit_manager=None):
         # Register in in-memory hot cache
         active_scans[scan_id] = {
             "task": task,
-            "created_at": datetime.now().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
             "ap_ips": ap_ips,
             "sm_ips": sm_ips,
             "snmp_communities": snmp_communities,
@@ -510,7 +510,7 @@ def health_check():
     return jsonify(
         {
             "status": "healthy",
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "active_scans": len(active_scans),
         }
     )

--- a/app/scan_task.py
+++ b/app/scan_task.py
@@ -10,7 +10,7 @@ Design: change-005 design § D4.5 — Scan Module Split
 import asyncio
 import threading
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from app.tower_scan import TowerScanner
@@ -62,7 +62,7 @@ class ScanTask:
 
     def log(self, msg: str, level: str = "info"):
         """Log message to console and internal buffer."""
-        timestamp = datetime.now().strftime("%H:%M:%S")
+        timestamp = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
         self.logs.append({"ts": timestamp, "msg": msg, "type": level})
 
         log_msg = f"[{self.scan_id}] {msg}"
@@ -603,7 +603,7 @@ class ScanTask:
             # Compilar resultados finales
             self.results = {
                 "scan_id": self.scan_id,
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "analysis_mode": self.analysis_mode,
                 "ap_count": len(self.ap_ips),
                 "sm_count": len(self.sm_ips),

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -323,8 +323,8 @@ async function checkStatus() {
             if (status.logs.length > appState.lastLogCount) {
                 const newLogs = status.logs.slice(appState.lastLogCount);
                 newLogs.forEach(log => {
-                    // Usar el tipo que viene del backend o default a info
-                    addLogEntry(log.msg, log.type || 'info');
+                    // Usar timestamp del servidor (log.ts) para trazabilidad exacta
+                    addLogEntry(log.msg, log.type || 'info', false, log.ts);
                 });
                 appState.lastLogCount = status.logs.length;
             }
@@ -806,13 +806,18 @@ function setStepperState(status) {
     });
 }
 
-function addLogEntry(msg, type = 'info', detailed = false) {
+function addLogEntry(msg, type = 'info', detailed = false, serverTs = null) {
     if (!elements.logOutput) return;
     if (detailed && elements.detailedLogToggle && !elements.detailedLogToggle.checked) return;
 
+    // Prefer server timestamp (backend UTC) when available, fallback to browser local time
+    const tsDisplay = serverTs
+        ? `[${serverTs}]`
+        : `[${new Date().toLocaleTimeString()}]`;
+
     const line = document.createElement('div');
     line.className = `log-line ${type}`;
-    line.innerHTML = `<span class="log-ts">[${new Date().toLocaleTimeString()}]</span><span class="log-msg">${msg}</span>`;
+    line.innerHTML = `<span class="log-ts">${tsDisplay}</span><span class="log-msg">${msg}</span>`;
     elements.logOutput.appendChild(line);
 
     // Auto-scroll inteligente


### PR DESCRIPTION
…atch

Backend:
- scan_task.py log(): datetime.now(timezone.utc) — logs now show 'HH:MM:SS UTC'
- scan_task.py results: datetime.now(timezone.utc).isoformat() — ISO with +00:00
- scan_routes.py created_at: datetime.now(timezone.utc).isoformat()
- scan_routes.py health: datetime.now(timezone.utc).isoformat()
- Add timezone to import in both files

Frontend:
- addLogEntry(): new serverTs param — uses backend log.ts when available (fallback: browser toLocaleTimeString for local-only events)
- checkStatus log loop: passes log.ts from backend to addLogEntry

Root cause: naive datetime.now() stores no TZ info; JS Date() parses ambiguous ISO strings as browser local time, causing drift between server time (Mexico City) and browser time in other zones.