### PR TITLE
fix(tower-scan): abort if any SM fails SNMP auth

### DIFF
--- a/app/tower_scan.py
+++ b/app/tower_scan.py
@@ -588,6 +588,20 @@ class TowerScanner:
             self._log("No hay APs válidos.", "error")
             return results
 
+        # CANDADO 0: Todos los SMs descubiertos deben responder SNMP
+        # Si hay SMs que no respondieron en AUTH, abortar
+        if errors:
+            failed_auth = list(errors.keys())
+            self._log(
+                f"ABORTO DE SEGURIDAD (Fase 0): {len(failed_auth)} SMs no respondieron SNMP: {failed_auth}",
+                "error",
+            )
+            self._log(
+                f"Se requieren {len(valid_sms) + len(failed_auth)} SMs operativos, pero solo {len(valid_sms)} respondieron.",
+                "warning",
+            )
+            return results
+
         # =========================================================================
         # FASE 1: PREPARACIÓN DE SMs (Configurar Modo)
         # =========================================================================


### PR DESCRIPTION
- Add CANDADO 0: abort scan if any SM fails FASE 0-AUTH (SNMP validation)
- Require 100% SMs responding before scan proceeds
- Add safety lock to prevent scan with incomplete SMs