### PR TITLE
fix(apply): send bandwidthScan to SMs on frequency apply

### DIFF
--- a/app/freq_apply_manager.py
+++ b/app/freq_apply_manager.py
@@ -73,7 +73,7 @@ class FrequencyApplyManager:
         freq_mhz: float,
         tower_id: str,
         applied_by: str,
-        channel_width_mhz: float = None,
+        channel_width_mhz: Optional[float] = None,
         force: bool = False,
     ) -> Dict:
         """Validate viability and execute the apply sequence.
@@ -118,9 +118,7 @@ class FrequencyApplyManager:
                 is_viable = best_combined.get("is_viable", False)
                 combined_score = best_combined.get("combined_score", 0.0)
                 if not is_viable:
-                    raise ValueError(
-                        "Analysis not viable. Use force=true to override."
-                    )
+                    raise ValueError("Analysis not viable. Use force=true to override.")
                 if combined_score < _VIABILITY_SCORE_THRESHOLD:
                     raise ValueError(
                         f"combined_score {combined_score:.2f} is below threshold "
@@ -128,7 +126,9 @@ class FrequencyApplyManager:
                     )
             elif best_ap:
                 # AP_ONLY path — 'Válido'='Sí' is the viability signal
-                is_viable_ap = best_ap.get("Válido") == "Sí" or best_ap.get("is_optimal", False)
+                is_viable_ap = best_ap.get("Válido") == "Sí" or best_ap.get(
+                    "is_optimal", False
+                )
                 if not is_viable_ap:
                     raise ValueError(
                         "Analysis not viable (AP_ONLY). Use force=true to override."
@@ -198,17 +198,62 @@ class FrequencyApplyManager:
         )
         logger.info(
             "[APPLY %d] Created: tower=%s scan=%s freq=%d kHz applied_by=%s",
-            apply_id, tower_id, scan_id, freq_khz, applied_by,
+            apply_id,
+            tower_id,
+            scan_id,
+            freq_khz,
+            applied_by,
         )
 
-        # ── Step 2: SET rfScanList on all SMs (SM-first) ─────────────────
+        # ── Step 2: SET rfScanList + bandwidthScan on all SMs (SM-first) ──
+        #
+        # Secuencia por SM:
+        #   a) bandwidthScan.0 — ancho de canal permitido para re-registro
+        #   b) rfScanList      — frecuencias a escanear
+        #
+        # bandwidthScan se envía SIEMPRE que channel_width esté disponible.
+        # Si falla bandwidthScan pero rfScanList OK → warning, no fatal.
+        # Si falla rfScanList → SM se marca como fallido.
         sm_results: Dict[str, Dict] = {}
         sm_failures: List[str] = []
 
         if sm_ips:
             for sm_ip in sm_ips:
+                sm_entry: Dict = {}
+
+                # 2a. SET bandwidthScan (si channel_width disponible)
+                if channel_width:
+                    bw_ok, bw_msg = self._scanner.set_sm_bandwidth_scan(
+                        sm_ip, channel_width
+                    )
+                    sm_entry["bw_scan"] = {
+                        "success": bw_ok,
+                        "error": bw_msg if not bw_ok else None,
+                    }
+                    if bw_ok:
+                        logger.info(
+                            "[APPLY %d] SM %s: bandwidthScan=%d MHz OK",
+                            apply_id,
+                            sm_ip,
+                            channel_width,
+                        )
+                    else:
+                        # Non-fatal: SM puede seguir con rfScanList
+                        errors.append(f"SM {sm_ip} bandwidthScan: {bw_msg}")
+                        logger.warning(
+                            "[APPLY %d] SM %s bandwidthScan failed (non-fatal): %s",
+                            apply_id,
+                            sm_ip,
+                            bw_msg,
+                        )
+
+                # 2b. SET rfScanList (frecuencia — siempre)
                 success, msg = self._scanner.set_sm_scan_list(sm_ip, [freq_khz])
-                sm_results[sm_ip] = {"success": success, "error": msg if not success else None}
+                sm_entry["success"] = success
+                sm_entry["error"] = msg if not success else None
+
+                sm_results[sm_ip] = sm_entry
+
                 if not success:
                     sm_failures.append(sm_ip)
                     errors.append(f"SM {sm_ip}: {msg}")
@@ -234,7 +279,9 @@ class FrequencyApplyManager:
         ap_result_json = json.dumps(ap_result)
 
         if ap_success:
-            logger.info("[APPLY %d] AP %s: rfFreqCarrier=%d kHz OK", apply_id, ap_ip, freq_khz)
+            logger.info(
+                "[APPLY %d] AP %s: rfFreqCarrier=%d kHz OK", apply_id, ap_ip, freq_khz
+            )
         else:
             errors.append(f"AP {ap_ip}: {ap_msg}")
             logger.error("[APPLY %d] AP %s failed: %s", apply_id, ap_ip, ap_msg)
@@ -247,13 +294,25 @@ class FrequencyApplyManager:
             bw_success, bw_msg = self._scanner.set_channel_width(
                 ap_ip, channel_width, ap_freq_mhz=ap_freq_mhz
             )
-            channel_width_result = {"success": bw_success, "error": bw_msg if not bw_success else None}
+            channel_width_result = {
+                "success": bw_success,
+                "error": bw_msg if not bw_success else None,
+            }
             if bw_success:
-                logger.info("[APPLY %d] AP %s: channelBandwidth=%d MHz OK", apply_id, ap_ip, channel_width)
+                logger.info(
+                    "[APPLY %d] AP %s: channelBandwidth=%d MHz OK",
+                    apply_id,
+                    ap_ip,
+                    channel_width,
+                )
             else:
                 # NO falla el apply — solo warning
                 errors.append(f"channel_width {ap_ip}: {bw_msg}")
-                logger.warning("[APPLY %d] channelBandwidth SET falló (non-fatal): %s", apply_id, bw_msg)
+                logger.warning(
+                    "[APPLY %d] channelBandwidth SET falló (non-fatal): %s",
+                    apply_id,
+                    bw_msg,
+                )
 
         # ── Step 4c: SET contention_slots = 4 (OBLIGATORIO, non-fatal) ────
         ct_success, ct_msg = self._scanner.set_contention_slots(ap_ip)
@@ -261,7 +320,11 @@ class FrequencyApplyManager:
             logger.info("[APPLY %d] AP %s: contention_slots=4 OK", apply_id, ap_ip)
         else:
             errors.append(f"contention_slots {ap_ip}: {ct_msg}")
-            logger.warning("[APPLY %d] contention_slots SET falló (non-fatal): %s", apply_id, ct_msg)
+            logger.warning(
+                "[APPLY %d] contention_slots SET falló (non-fatal): %s",
+                apply_id,
+                ct_msg,
+            )
 
         # ── Step 4d: SET broadcast_retry = 0 (OBLIGATORIO, non-fatal) ─────
         br_success, br_msg = self._scanner.set_broadcast_retry(ap_ip)
@@ -269,17 +332,25 @@ class FrequencyApplyManager:
             logger.info("[APPLY %d] AP %s: broadcastRetryCount=0 OK", apply_id, ap_ip)
         else:
             errors.append(f"broadcast_retry {ap_ip}: {br_msg}")
-            logger.warning("[APPLY %d] broadcast_retry SET falló (non-fatal): %s", apply_id, br_msg)
+            logger.warning(
+                "[APPLY %d] broadcast_retry SET falló (non-fatal): %s", apply_id, br_msg
+            )
 
         # ── Step 4e: rebootIfRequired = 1 (SIEMPRE, último paso) ──────────
         # El equipo evaluará si los cambios requieren reinicio y lo ejecutará
         # automáticamente. El AP quedará inaccesible ~30-60 s (esperado).
         rb_success, rb_msg = self._scanner.reboot_if_required(ap_ip)
         if rb_success:
-            logger.info("[APPLY %d] AP %s: rebootIfRequired=1 enviado OK", apply_id, ap_ip)
+            logger.info(
+                "[APPLY %d] AP %s: rebootIfRequired=1 enviado OK", apply_id, ap_ip
+            )
         else:
             errors.append(f"reboot {ap_ip}: {rb_msg}")
-            logger.warning("[APPLY %d] reboot_if_required SET falló (non-fatal): %s", apply_id, rb_msg)
+            logger.warning(
+                "[APPLY %d] reboot_if_required SET falló (non-fatal): %s",
+                apply_id,
+                rb_msg,
+            )
 
         # ── Step 5: Determine final state ─────────────────────────────────
         # State machine rules (from spec Domain 8):

--- a/app/routes/apply_routes.py
+++ b/app/routes/apply_routes.py
@@ -41,6 +41,7 @@ apply_bp = Blueprint("apply", __name__)
 
 # ── RBAC helper ──────────────────────────────────────────────────────────────
 
+
 def _require_operator_or_admin():
     """Return a 403 JSON response if the current session role is 'viewer'.
 
@@ -54,6 +55,7 @@ def _require_operator_or_admin():
 
 
 # ── Manager factory ──────────────────────────────────────────────────────────
+
 
 def _get_freq_apply_manager() -> FrequencyApplyManager:
     """Instantiate FrequencyApplyManager from app.config managers.
@@ -92,7 +94,7 @@ def apply_frequency():
         scan_id (str, required)         — completed scan to use as source
         freq_mhz (float, required)      — target frequency in MHz
         tower_id (str, required)        — tower identifier
-        channel_width_mhz (float, opt) — channel width in MHz (stored, SET deferred)
+        channel_width_mhz (float, opt) — channel width in MHz (SET on SMs + AP)
         force (bool, opt, default false)— bypass viability check (admin only)
 
     Returns:
@@ -180,4 +182,6 @@ def get_apply_history(tower_id: str):
 
     except Exception as exc:
         logger.exception("[get_apply_history] tower_id=%s error: %s", tower_id, exc)
-        return jsonify({"error": "Failed to retrieve apply history", "detail": str(exc)}), 500
+        return jsonify(
+            {"error": "Failed to retrieve apply history", "detail": str(exc)}
+        ), 500

--- a/app/scan_task.py
+++ b/app/scan_task.py
@@ -850,6 +850,7 @@ class ScanTask:
             is_viable = best.get("is_viable", False)
             combined_score = best.get("combined_score", 0.0)
             freq_mhz = best.get("frequency")
+            bw_mhz = best.get("bandwidth")
 
             if not is_viable or combined_score < 0.65 or not freq_mhz:
                 self.log(
@@ -872,6 +873,7 @@ class ScanTask:
                     tower_id=tower_id or ap_ip,  # fallback: use AP IP as tower_id
                     applied_by="auto",
                     force=False,  # auto-apply never bypasses viability gate
+                    channel_width_mhz=float(bw_mhz) if bw_mhz else None,
                 )
                 state = result.get("state", "unknown")
                 apply_id = result.get("apply_id")

--- a/app/tower_scan.py
+++ b/app/tower_scan.py
@@ -57,6 +57,9 @@ class TowerScanner:
     RF_SCAN_LIST_OID = (
         "1.3.6.1.4.1.161.19.3.2.1.1.0"  # SM — OctetString, kHz separado por coma
     )
+    SM_BW_SCAN_OID = (
+        "1.3.6.1.4.1.161.19.3.2.1.131.0"  # SM — bandwidthScan.0, OctetString
+    )
 
     # Valores de control
     SET_FULL_SCAN = 8
@@ -932,6 +935,49 @@ class TowerScanner:
             self._log(f"[APPLY] {ip}: SET rfScanList OK — '{scan_list_str}'", "info")
         else:
             self._log(f"[APPLY] {ip}: FALLÓ set_sm_scan_list — {msg}", "error")
+
+        return success, msg
+
+    def set_sm_bandwidth_scan(self, ip: str, width_mhz: int) -> Tuple[bool, str]:
+        """SET bandwidthScan.0 on SM via SNMP — configures allowed channel widths.
+
+        OID: .1.3.6.1.4.1.161.19.3.2.1.131.0 (bandwidthScan.0, OctetString)
+        Value format: "20.0 MHz" (text string matching the target bandwidth).
+
+        MUST be called BEFORE changing AP bandwidth so the SM knows which
+        channel widths to scan for when re-registering after reboot.
+
+        Args:
+            ip:        SM IP address.
+            width_mhz: Channel bandwidth in MHz (5, 7, 10, 15, 20, 30, 40).
+
+        Returns:
+            Tuple (success: bool, message: str).
+        """
+        VALID_BWS = [5, 7, 10, 15, 20, 30, 40]
+        width_mhz = int(width_mhz)
+        if width_mhz not in VALID_BWS:
+            return False, (
+                f"Ancho de canal {width_mhz} MHz no soportado para SM. "
+                f"Válidos: {VALID_BWS}"
+            )
+
+        bw_str = f"{float(width_mhz):.1f} MHz"  # → "20.0 MHz"
+        self._log(
+            f"[APPLY] {ip}: SET bandwidthScan = '{bw_str}' (OID {self.SM_BW_SCAN_OID})",
+            "info",
+        )
+
+        success, msg = self._snmp_set_string(
+            ip=ip,
+            oid=self.SM_BW_SCAN_OID,
+            value=bw_str,
+        )
+
+        if success:
+            self._log(f"[APPLY] {ip}: SET bandwidthScan='{bw_str}' OK", "info")
+        else:
+            self._log(f"[APPLY] {ip}: FALLÓ set_sm_bandwidth_scan — {msg}", "error")
 
         return success, msg
 

--- a/tests/test_freq_apply_manager.py
+++ b/tests/test_freq_apply_manager.py
@@ -36,7 +36,12 @@ def scanner():
     """Mock TowerScanner with all SNMP methods stubbed to succeed."""
     mock = MagicMock()
     mock.set_sm_scan_list.return_value = (True, "OK")
+    mock.set_sm_bandwidth_scan.return_value = (True, "OK")
     mock.set_frequency.return_value = (True, "OK")
+    mock.set_channel_width.return_value = (True, "OK")
+    mock.set_contention_slots.return_value = (True, "OK")
+    mock.set_broadcast_retry.return_value = (True, "OK")
+    mock.reboot_if_required.return_value = (True, "OK")
     mock._snmp_get.return_value = (True, 5180000, "OK")
     return mock
 
@@ -88,25 +93,40 @@ class TestViabilityGate:
 
     def test_raises_when_not_viable(self, manager, db):
         """GIVEN is_viable=False and force=False THEN ValueError raised."""
-        _insert_scan(db, "S1", ["192.168.1.10"], results={
-            "best_combined_frequency": {"is_viable": False, "combined_score": 0.80}
-        })
+        _insert_scan(
+            db,
+            "S1",
+            ["192.168.1.10"],
+            results={
+                "best_combined_frequency": {"is_viable": False, "combined_score": 0.80}
+            },
+        )
         with pytest.raises(ValueError, match="not viable"):
             manager.run_apply("S1", 5180.0, "TORRE-01", "admin", force=False)
 
     def test_raises_when_score_below_threshold(self, manager, db):
         """GIVEN combined_score=0.50 and force=False THEN ValueError raised."""
-        _insert_scan(db, "S2", ["192.168.1.10"], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.50}
-        })
+        _insert_scan(
+            db,
+            "S2",
+            ["192.168.1.10"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.50}
+            },
+        )
         with pytest.raises(ValueError, match="0.50"):
             manager.run_apply("S2", 5180.0, "TORRE-01", "admin", force=False)
 
     def test_force_bypasses_viability(self, manager, db, scanner):
         """GIVEN is_viable=False and force=True THEN apply proceeds without error."""
-        _insert_scan(db, "S3", ["192.168.1.10"], results={
-            "best_combined_frequency": {"is_viable": False, "combined_score": 0.30}
-        })
+        _insert_scan(
+            db,
+            "S3",
+            ["192.168.1.10"],
+            results={
+                "best_combined_frequency": {"is_viable": False, "combined_score": 0.30}
+            },
+        )
         result = manager.run_apply("S3", 5180.0, "TORRE-01", "admin", force=True)
         assert result["state"] == "completed"
 
@@ -117,9 +137,14 @@ class TestViabilityGate:
 
     def test_passes_when_viable_and_good_score(self, manager, db, scanner):
         """GIVEN is_viable=True and combined_score=0.80 THEN apply proceeds."""
-        _insert_scan(db, "S4", ["192.168.1.10"], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.80}
-        })
+        _insert_scan(
+            db,
+            "S4",
+            ["192.168.1.10"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.80}
+            },
+        )
         result = manager.run_apply("S4", 5180.0, "TORRE-01", "admin", force=False)
         assert result["state"] == "completed"
 
@@ -133,12 +158,24 @@ class TestStateMachine:
     def test_sm_first_ap_last_order(self, manager, db, scanner):
         """GIVEN scan with 1 SM THEN set_sm_scan_list called BEFORE set_frequency."""
         call_order = []
-        scanner.set_sm_scan_list.side_effect = lambda *a, **kw: (call_order.append("SM"), (True, "OK"))[1]
-        scanner.set_frequency.side_effect = lambda *a, **kw: (call_order.append("AP"), (True, "OK"))[1]
+        scanner.set_sm_scan_list.side_effect = lambda *a, **kw: (
+            call_order.append("SM"),
+            (True, "OK"),
+        )[1]
+        scanner.set_frequency.side_effect = lambda *a, **kw: (
+            call_order.append("AP"),
+            (True, "OK"),
+        )[1]
 
-        _insert_scan(db, "S5", ["192.168.1.10"], sm_ips=["192.168.1.20"], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
+        _insert_scan(
+            db,
+            "S5",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
         manager.run_apply("S5", 5180.0, "TORRE-01", "admin", force=False)
 
         assert call_order == ["SM", "AP"], f"Expected SM then AP, got: {call_order}"
@@ -147,9 +184,14 @@ class TestStateMachine:
         """GIVEN AP SET fails THEN final state is 'failed'."""
         scanner.set_frequency.return_value = (False, "Timeout")
 
-        _insert_scan(db, "S6", ["192.168.1.10"], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
+        _insert_scan(
+            db,
+            "S6",
+            ["192.168.1.10"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
         result = manager.run_apply("S6", 5180.0, "TORRE-01", "admin", force=False)
         assert result["state"] == "failed"
         assert not result["success"]
@@ -157,15 +199,19 @@ class TestStateMachine:
     def test_partial_sm_failure_ap_ok_yields_completed(self, manager, db, scanner):
         """GIVEN 1 SM fails and AP succeeds THEN state is 'completed' but errors not empty."""
         scanner.set_sm_scan_list.side_effect = [
-            (True, "OK"),   # SM1 OK
+            (True, "OK"),  # SM1 OK
             (False, "Timeout"),  # SM2 fails
         ]
         scanner.set_frequency.return_value = (True, "OK")
 
         _insert_scan(
-            db, "S7", ["192.168.1.10"],
+            db,
+            "S7",
+            ["192.168.1.10"],
             sm_ips=["192.168.1.20", "192.168.1.21"],
-            results={"best_combined_frequency": {"is_viable": True, "combined_score": 0.90}},
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
         )
         result = manager.run_apply("S7", 5180.0, "TORRE-01", "admin", force=False)
         assert result["state"] == "completed"
@@ -174,34 +220,63 @@ class TestStateMachine:
 
     def test_no_sm_skips_sm_step(self, manager, db, scanner):
         """GIVEN scan with no SMs THEN set_sm_scan_list not called."""
-        _insert_scan(db, "S8", ["192.168.1.10"], sm_ips=[], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
+        _insert_scan(
+            db,
+            "S8",
+            ["192.168.1.10"],
+            sm_ips=[],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
         manager.run_apply("S8", 5180.0, "TORRE-01", "admin", force=False)
         scanner.set_sm_scan_list.assert_not_called()
 
     def test_result_dict_contains_required_keys(self, manager, db, scanner):
         """GIVEN successful apply THEN result has all expected keys."""
-        _insert_scan(db, "S9", ["192.168.1.10"], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
+        _insert_scan(
+            db,
+            "S9",
+            ["192.168.1.10"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
         result = manager.run_apply("S9", 5180.0, "TORRE-01", "admin", force=False)
-        for key in ("success", "apply_id", "state", "freq_khz", "sm_results", "ap_result", "errors"):
+        for key in (
+            "success",
+            "apply_id",
+            "state",
+            "freq_khz",
+            "sm_results",
+            "ap_result",
+            "errors",
+        ):
             assert key in result, f"Missing key: {key}"
 
     def test_freq_khz_is_conversion_of_mhz(self, manager, db, scanner):
         """GIVEN freq_mhz=5180.0 THEN result.freq_khz == 5180000."""
-        _insert_scan(db, "S10", ["192.168.1.10"], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
+        _insert_scan(
+            db,
+            "S10",
+            ["192.168.1.10"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
         result = manager.run_apply("S10", 5180.0, "TORRE-01", "admin", force=False)
         assert result["freq_khz"] == 5180000
 
     def test_apply_id_is_persisted_in_db(self, manager, db, scanner):
         """GIVEN successful apply THEN apply record exists in frequency_applies table."""
-        _insert_scan(db, "S11", ["192.168.1.10"], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
+        _insert_scan(
+            db,
+            "S11",
+            ["192.168.1.10"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
         result = manager.run_apply("S11", 5180.0, "TORRE-01", "admin", force=False)
         apply_id = result["apply_id"]
 
@@ -227,12 +302,24 @@ class TestGetApplyHistory:
 
     def test_returns_applies_for_tower(self, manager, db, scanner):
         """GIVEN 2 applies for TORRE-01 THEN get_apply_history returns 2 rows."""
-        _insert_scan(db, "HA1", ["192.168.1.10"], sm_ips=[], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
-        _insert_scan(db, "HA2", ["192.168.1.10"], sm_ips=[], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
+        _insert_scan(
+            db,
+            "HA1",
+            ["192.168.1.10"],
+            sm_ips=[],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        _insert_scan(
+            db,
+            "HA2",
+            ["192.168.1.10"],
+            sm_ips=[],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
         manager.run_apply("HA1", 5180.0, "TORRE-01", "admin", force=False)
         manager.run_apply("HA2", 5200.0, "TORRE-01", "admin", force=False)
 
@@ -241,12 +328,24 @@ class TestGetApplyHistory:
 
     def test_history_ordered_by_date_desc(self, manager, db, scanner):
         """GIVEN 2 applies THEN both records are returned (ORDER BY created_at DESC)."""
-        _insert_scan(db, "HB1", ["192.168.1.10"], sm_ips=[], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
-        _insert_scan(db, "HB2", ["192.168.1.10"], sm_ips=[], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
+        _insert_scan(
+            db,
+            "HB1",
+            ["192.168.1.10"],
+            sm_ips=[],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        _insert_scan(
+            db,
+            "HB2",
+            ["192.168.1.10"],
+            sm_ips=[],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
         manager.run_apply("HB1", 5180.0, "TORRE-01", "admin", force=False)
         manager.run_apply("HB2", 5200.0, "TORRE-01", "admin", force=False)
 
@@ -259,12 +358,26 @@ class TestGetApplyHistory:
 
     def test_history_does_not_mix_towers(self, manager, db, scanner):
         """GIVEN applies for TORRE-01 and TORRE-02 THEN histories are separate."""
-        _insert_scan(db, "HC1", ["192.168.1.10"], sm_ips=[], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        }, tower_id="TORRE-01")
-        _insert_scan(db, "HC2", ["192.168.1.10"], sm_ips=[], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        }, tower_id="TORRE-02")
+        _insert_scan(
+            db,
+            "HC1",
+            ["192.168.1.10"],
+            sm_ips=[],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+            tower_id="TORRE-01",
+        )
+        _insert_scan(
+            db,
+            "HC2",
+            ["192.168.1.10"],
+            sm_ips=[],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+            tower_id="TORRE-02",
+        )
         manager.run_apply("HC1", 5180.0, "TORRE-01", "admin", force=False)
         manager.run_apply("HC2", 5200.0, "TORRE-02", "admin", force=False)
 
@@ -277,9 +390,176 @@ class TestGetApplyHistory:
 
     def test_history_records_have_freq_mhz(self, manager, db, scanner):
         """GIVEN apply at 5180.0 MHz THEN history record has freq_mhz=5180.0."""
-        _insert_scan(db, "HD1", ["192.168.1.10"], sm_ips=[], results={
-            "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
-        })
+        _insert_scan(
+            db,
+            "HD1",
+            ["192.168.1.10"],
+            sm_ips=[],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
         manager.run_apply("HD1", 5180.0, "TORRE-01", "admin", force=False)
         history = manager.get_apply_history("TORRE-01")
         assert history[0]["freq_mhz"] == pytest.approx(5180.0)
+
+
+# ── bandwidthScan apply ───────────────────────────────────────────────────────
+
+
+class TestBandwidthApply:
+    """Tests for bandwidthScan SET on SMs when channel_width_mhz is provided."""
+
+    def test_bw_scan_called_before_rf_scan_list(self, manager, db, scanner):
+        """GIVEN channel_width_mhz=20 THEN bandwidthScan SET happens before rfScanList per SM."""
+        call_order = []
+        scanner.set_sm_bandwidth_scan.side_effect = lambda *a, **kw: (
+            call_order.append("bw"),
+            (True, "OK"),
+        )[1]
+        scanner.set_sm_scan_list.side_effect = lambda *a, **kw: (
+            call_order.append("rf"),
+            (True, "OK"),
+        )[1]
+
+        _insert_scan(
+            db,
+            "BW1",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        manager.run_apply(
+            "BW1", 5180.0, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
+        )
+
+        assert call_order == ["bw", "rf"], f"Expected bw then rf, got: {call_order}"
+
+    def test_bw_scan_passes_width_mhz(self, manager, db, scanner):
+        """GIVEN channel_width_mhz=30 THEN set_sm_bandwidth_scan receives 30."""
+        _insert_scan(
+            db,
+            "BW2",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        manager.run_apply(
+            "BW2", 5180.0, "TORRE-01", "admin", force=False, channel_width_mhz=30.0
+        )
+
+        args, _ = scanner.set_sm_bandwidth_scan.call_args
+        assert args[1] == 30.0
+
+    def test_bw_scan_not_called_when_no_channel_width(self, manager, db, scanner):
+        """GIVEN channel_width_mhz=None THEN set_sm_bandwidth_scan is NOT called."""
+        _insert_scan(
+            db,
+            "BW3",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        manager.run_apply(
+            "BW3", 5180.0, "TORRE-01", "admin", force=False, channel_width_mhz=None
+        )
+
+        scanner.set_sm_bandwidth_scan.assert_not_called()
+
+    def test_bw_scan_not_called_when_no_sms(self, manager, db, scanner):
+        """GIVEN no SMs THEN set_sm_bandwidth_scan is NOT called even with channel_width."""
+        _insert_scan(
+            db,
+            "BW4",
+            ["192.168.1.10"],
+            sm_ips=[],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        manager.run_apply(
+            "BW4", 5180.0, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
+        )
+
+        scanner.set_sm_bandwidth_scan.assert_not_called()
+
+    def test_bw_scan_failure_is_non_fatal(self, manager, db, scanner):
+        """GIVEN bandwidthScan fails but rfScanList succeeds THEN state is 'completed'."""
+        scanner.set_sm_bandwidth_scan.return_value = (False, "notWritable")
+        scanner.set_sm_scan_list.return_value = (True, "OK")
+
+        _insert_scan(
+            db,
+            "BW5",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        result = manager.run_apply(
+            "BW5", 5180.0, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
+        )
+
+        assert result["state"] == "completed"
+        assert result["success"] is True
+
+    def test_bw_scan_failure_adds_to_errors(self, manager, db, scanner):
+        """GIVEN bandwidthScan fails THEN result.errors contains the SM IP."""
+        scanner.set_sm_bandwidth_scan.return_value = (False, "timeout")
+
+        _insert_scan(
+            db,
+            "BW6",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        result = manager.run_apply(
+            "BW6", 5180.0, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
+        )
+
+        assert any("192.168.1.20" in e for e in result["errors"])
+
+    def test_bw_scan_called_for_each_sm(self, manager, db, scanner):
+        """GIVEN 2 SMs THEN set_sm_bandwidth_scan is called twice."""
+        _insert_scan(
+            db,
+            "BW7",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20", "192.168.1.21"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        manager.run_apply(
+            "BW7", 5180.0, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
+        )
+
+        assert scanner.set_sm_bandwidth_scan.call_count == 2
+
+    def test_apply_succeeds_with_channel_width(self, manager, db, scanner):
+        """GIVEN full apply with channel_width_mhz=20 THEN state is 'completed'."""
+        _insert_scan(
+            db,
+            "BW8",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        result = manager.run_apply(
+            "BW8", 5180.0, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
+        )
+
+        assert result["state"] == "completed"
+        assert result["success"] is True

--- a/tests/test_tower_scan_set.py
+++ b/tests/test_tower_scan_set.py
@@ -57,27 +57,35 @@ class TestSetFrequency:
 
     def test_returns_true_on_success(self, scanner):
         """GIVEN successful SNMP SET THEN returns (True, 'OK')."""
-        with patch.object(tower_scan_module, "setCmd", return_value=_mock_setcmd_success()):
+        with patch.object(
+            tower_scan_module, "setCmd", return_value=_mock_setcmd_success()
+        ):
             success, msg = scanner.set_frequency("192.168.1.10", 5180000)
         assert success is True
         assert "OK" in msg
 
     def test_returns_false_on_snmp_error(self, scanner):
         """GIVEN SNMP timeout THEN returns (False, error_string)."""
-        with patch.object(tower_scan_module, "setCmd", return_value=_mock_setcmd_timeout()):
+        with patch.object(
+            tower_scan_module, "setCmd", return_value=_mock_setcmd_timeout()
+        ):
             success, msg = scanner.set_frequency("192.168.1.10", 5180000)
         assert success is False
 
     def test_logs_apply_message(self, scanner):
         """GIVEN set_frequency call THEN _log is invoked (observability)."""
-        with patch.object(tower_scan_module, "setCmd", return_value=_mock_setcmd_success()):
+        with patch.object(
+            tower_scan_module, "setCmd", return_value=_mock_setcmd_success()
+        ):
             with patch.object(scanner, "_log") as mock_log:
                 scanner.set_frequency("192.168.1.10", 5180000)
                 assert mock_log.called
 
     def test_handles_exception_gracefully(self, scanner):
         """GIVEN setCmd raises Exception THEN returns (False, str) without propagating."""
-        with patch.object(tower_scan_module, "setCmd", side_effect=Exception("Connection refused")):
+        with patch.object(
+            tower_scan_module, "setCmd", side_effect=Exception("Connection refused")
+        ):
             success, msg = scanner.set_frequency("192.168.1.10", 5180000)
         assert success is False
         assert "Connection refused" in msg
@@ -99,7 +107,9 @@ class TestSetFrequency:
         with patch.object(tower_scan_module, "setCmd", side_effect=capture_setcmd):
             scanner.set_frequency("192.168.1.10", 5180000)
 
-        assert len(calls) == 1, "setCmd must be called exactly once per set_frequency() call"
+        assert len(calls) == 1, (
+            "setCmd must be called exactly once per set_frequency() call"
+        )
 
 
 # ── set_sm_scan_list() ────────────────────────────────────────────────────────
@@ -110,27 +120,35 @@ class TestSetSmScanList:
 
     def test_delegates_to_snmp_set_string(self, scanner):
         """GIVEN set_sm_scan_list call THEN _snmp_set_string is called once."""
-        with patch.object(scanner, "_snmp_set_string", return_value=(True, "OK")) as mock_set:
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
             scanner.set_sm_scan_list("192.168.1.20", [5180000])
         mock_set.assert_called_once()
 
     def test_passes_rf_scan_list_oid(self, scanner):
         """GIVEN set_sm_scan_list THEN _snmp_set_string receives RF_SCAN_LIST_OID."""
-        with patch.object(scanner, "_snmp_set_string", return_value=(True, "OK")) as mock_set:
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
             scanner.set_sm_scan_list("192.168.1.20", [5180000])
         _, kwargs = mock_set.call_args
         assert kwargs.get("oid") == TowerScanner.RF_SCAN_LIST_OID
 
     def test_passes_correct_ip(self, scanner):
         """GIVEN IP '192.168.1.20' THEN _snmp_set_string receives that IP."""
-        with patch.object(scanner, "_snmp_set_string", return_value=(True, "OK")) as mock_set:
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
             scanner.set_sm_scan_list("192.168.1.20", [5180000])
         _, kwargs = mock_set.call_args
         assert kwargs.get("ip") == "192.168.1.20"
 
     def test_single_freq_formatted_correctly(self, scanner):
         """GIVEN [5180000] THEN value is '5180000' (no trailing comma)."""
-        with patch.object(scanner, "_snmp_set_string", return_value=(True, "OK")) as mock_set:
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
             scanner.set_sm_scan_list("192.168.1.20", [5180000])
         _, kwargs = mock_set.call_args
         value = kwargs.get("value")
@@ -140,7 +158,9 @@ class TestSetSmScanList:
 
     def test_multiple_freqs_formatted_as_csv(self, scanner):
         """GIVEN [5180000, 5200000] THEN value uses ', ' separator (rfScanList OID format)."""
-        with patch.object(scanner, "_snmp_set_string", return_value=(True, "OK")) as mock_set:
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
             scanner.set_sm_scan_list("192.168.1.20", [5180000, 5200000])
         _, kwargs = mock_set.call_args
         value = kwargs.get("value")
@@ -156,6 +176,90 @@ class TestSetSmScanList:
 
     def test_returns_false_on_failure(self, scanner):
         """GIVEN failed write THEN returns (False, error)."""
-        with patch.object(scanner, "_snmp_set_string", return_value=(False, "notWritable")):
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(False, "notWritable")
+        ):
             success, msg = scanner.set_sm_scan_list("192.168.1.20", [5180000])
         assert success is False
+
+
+# ── set_sm_bandwidth_scan() ───────────────────────────────────────────────────
+
+
+class TestSetSmBandwidthScan:
+    """Tests for TowerScanner.set_sm_bandwidth_scan() — bandwidthScan via _snmp_set_string()."""
+
+    def test_delegates_to_snmp_set_string(self, scanner):
+        """GIVEN set_sm_bandwidth_scan call THEN _snmp_set_string is called once."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
+            scanner.set_sm_bandwidth_scan("192.168.1.20", 20)
+        mock_set.assert_called_once()
+
+    def test_passes_sm_bw_scan_oid(self, scanner):
+        """GIVEN set_sm_bandwidth_scan THEN _snmp_set_string receives SM_BW_SCAN_OID."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
+            scanner.set_sm_bandwidth_scan("192.168.1.20", 20)
+        _, kwargs = mock_set.call_args
+        assert kwargs.get("oid") == TowerScanner.SM_BW_SCAN_OID
+
+    def test_passes_correct_ip(self, scanner):
+        """GIVEN IP '192.168.1.20' THEN _snmp_set_string receives that IP."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
+            scanner.set_sm_bandwidth_scan("192.168.1.20", 20)
+        _, kwargs = mock_set.call_args
+        assert kwargs.get("ip") == "192.168.1.20"
+
+    def test_value_formatted_with_mhz_suffix(self, scanner):
+        """GIVEN width_mhz=20 THEN value is '20.0 MHz'."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
+            scanner.set_sm_bandwidth_scan("192.168.1.20", 20)
+        _, kwargs = mock_set.call_args
+        assert kwargs.get("value") == "20.0 MHz"
+
+    def test_value_10mhz(self, scanner):
+        """GIVEN width_mhz=10 THEN value is '10.0 MHz'."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
+            scanner.set_sm_bandwidth_scan("192.168.1.20", 10)
+        _, kwargs = mock_set.call_args
+        assert kwargs.get("value") == "10.0 MHz"
+
+    def test_value_30mhz(self, scanner):
+        """GIVEN width_mhz=30 THEN value is '30.0 MHz'."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
+            scanner.set_sm_bandwidth_scan("192.168.1.20", 30)
+        _, kwargs = mock_set.call_args
+        assert kwargs.get("value") == "30.0 MHz"
+
+    def test_returns_true_on_success(self, scanner):
+        """GIVEN successful write THEN returns (True, msg)."""
+        with patch.object(scanner, "_snmp_set_string", return_value=(True, "OK")):
+            success, _ = scanner.set_sm_bandwidth_scan("192.168.1.20", 20)
+        assert success is True
+
+    def test_returns_false_on_failure(self, scanner):
+        """GIVEN failed write THEN returns (False, error)."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(False, "notWritable")
+        ):
+            success, msg = scanner.set_sm_bandwidth_scan("192.168.1.20", 20)
+        assert success is False
+        assert "notWritable" in msg
+
+    def test_logs_apply_message(self, scanner):
+        """GIVEN set_sm_bandwidth_scan call THEN _log is invoked (observability)."""
+        with patch.object(scanner, "_snmp_set_string", return_value=(True, "OK")):
+            with patch.object(scanner, "_log") as mock_log:
+                scanner.set_sm_bandwidth_scan("192.168.1.20", 20)
+                assert mock_log.called


### PR DESCRIPTION
Closes #46

### Type
- [x] Bug fix

### Summary
- Added `set_sm_bandwidth_scan()` to `TowerScanner` (OID `.1.3.6.1.4.1.161.19.3.2.1.131.0`)
- Expanded Step 2 in `FrequencyApplyManager._apply()` to send `bandwidthScan` to each SM before `rfScanList`
- `_run_auto_apply()` now passes `channel_width_mhz` from cross-analysis `best.bandwidth`

### Changes

| File | Change |
|------|--------|
| `app/tower_scan.py` | New `set_sm_bandwidth_scan()` + `SM_BW_SCAN_OID` constant |
| `app/freq_apply_manager.py` | Step 2: bandwidthScan → rfScanList per SM; `Optional[float]` type fix |
| `app/scan_task.py` | Auto-apply passes `channel_width_mhz` from `best.bandwidth` |
| `app/routes/apply_routes.py` | Docstring update |
| `tests/test_tower_scan_set.py` | 9 new tests for `set_sm_bandwidth_scan()` |
| `tests/test_freq_apply_manager.py` | 8 new tests in `TestBandwidthApply` |

### Test Plan
- [x] `py -3.13 -m pytest tests/test_tower_scan_set.py tests/test_freq_apply_manager.py` — **46/46 pass**