### PR TITLE
fix(apply): make-before-break — merge current + new freq/bw on SMs

### DIFF
--- a/app/freq_apply_manager.py
+++ b/app/freq_apply_manager.py
@@ -221,10 +221,72 @@ class FrequencyApplyManager:
             for sm_ip in sm_ips:
                 sm_entry: Dict = {}
 
-                # 2a. SET bandwidthScan (si channel_width disponible)
+                # ── Make-Before-Break: GET current config before SET ──────────
+                # Read current rfScanList and bandwidthScan from SM so we can
+                # merge (not replace) — if AP rolls back, SM can still find it.
+
+                # 2a. GET current rfScanList (best-effort, non-fatal on failure)
+                get_ok, current_freqs, get_msg = self._scanner.get_sm_scan_list(sm_ip)
+                if not get_ok:
+                    logger.warning(
+                        "[APPLY %d] SM %s: GET rfScanList failed (non-fatal) — %s. "
+                        "Falling back to new-only.",
+                        apply_id,
+                        sm_ip,
+                        get_msg,
+                    )
+                    current_freqs = []
+
+                # Merge: deduplicated union of current + new frequency
+                merged_freqs = list(dict.fromkeys(current_freqs + [freq_khz]))
+                logger.info(
+                    "[APPLY] SM %s: merging rfScanList: current=%s + new=%s → merged=%s",
+                    sm_ip,
+                    current_freqs,
+                    [freq_khz],
+                    merged_freqs,
+                )
+
+                # 2b. GET current bandwidthScan (best-effort, non-fatal on failure)
                 if channel_width:
+                    bw_get_ok, current_bws, bw_get_msg = (
+                        self._scanner.get_sm_bandwidth_scan(sm_ip)
+                    )
+                    if not bw_get_ok:
+                        logger.warning(
+                            "[APPLY %d] SM %s: GET bandwidthScan failed (non-fatal) — %s. "
+                            "Falling back to new-only.",
+                            apply_id,
+                            sm_ip,
+                            bw_get_msg,
+                        )
+                        current_bws = []
+
+                    new_bw_str = f"{float(channel_width):.1f} MHz"
+                    # Merge: deduplicated union of current + new bandwidth strings
+                    merged_bws_str = list(dict.fromkeys(current_bws + [new_bw_str]))
+                    logger.info(
+                        "[APPLY] SM %s: merging bandwidthScan: current=%s + new=%s → merged=%s",
+                        sm_ip,
+                        current_bws,
+                        [new_bw_str],
+                        merged_bws_str,
+                    )
+
+                    # Convert merged bandwidth strings back to int list for the setter
+                    # e.g. ["15.0 MHz", "20.0 MHz"] → [15, 20]
+                    merged_bws_int = []
+                    for bw_s in merged_bws_str:
+                        try:
+                            merged_bws_int.append(
+                                int(float(bw_s.replace("MHz", "").strip()))
+                            )
+                        except ValueError:
+                            pass  # Skip malformed values
+
+                    # 2c. SET bandwidthScan with merged list
                     bw_ok, bw_msg = self._scanner.set_sm_bandwidth_scan(
-                        sm_ip, channel_width
+                        sm_ip, merged_bws_int
                     )
                     sm_entry["bw_scan"] = {
                         "success": bw_ok,
@@ -232,10 +294,10 @@ class FrequencyApplyManager:
                     }
                     if bw_ok:
                         logger.info(
-                            "[APPLY %d] SM %s: bandwidthScan=%d MHz OK",
+                            "[APPLY %d] SM %s: bandwidthScan=%s OK",
                             apply_id,
                             sm_ip,
-                            channel_width,
+                            merged_bws_str,
                         )
                     else:
                         # Non-fatal: SM puede seguir con rfScanList
@@ -247,8 +309,8 @@ class FrequencyApplyManager:
                             bw_msg,
                         )
 
-                # 2b. SET rfScanList (frecuencia — siempre)
-                success, msg = self._scanner.set_sm_scan_list(sm_ip, [freq_khz])
+                # 2d. SET rfScanList with merged list (frecuencia — siempre)
+                success, msg = self._scanner.set_sm_scan_list(sm_ip, merged_freqs)
                 sm_entry["success"] = success
                 sm_entry["error"] = msg if not success else None
 

--- a/app/tower_scan.py
+++ b/app/tower_scan.py
@@ -17,7 +17,7 @@ import logging
 # que pysnmp puede retornar cuando str() se aplica sobre IpAddress objects.
 _IPV4_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 
-from app.freq_utils import format_scan_list
+from app.freq_utils import format_scan_list, parse_scan_list
 
 
 @dataclass
@@ -938,31 +938,45 @@ class TowerScanner:
 
         return success, msg
 
-    def set_sm_bandwidth_scan(self, ip: str, width_mhz: int) -> Tuple[bool, str]:
+    def set_sm_bandwidth_scan(
+        self, ip: str, width_mhz: "int | List[int]"
+    ) -> Tuple[bool, str]:
         """SET bandwidthScan.0 on SM via SNMP — configures allowed channel widths.
 
         OID: .1.3.6.1.4.1.161.19.3.2.1.131.0 (bandwidthScan.0, OctetString)
-        Value format: "20.0 MHz" (text string matching the target bandwidth).
+        Value format: "20.0 MHz" or "15.0 MHz, 20.0 MHz" (comma-separated).
 
         MUST be called BEFORE changing AP bandwidth so the SM knows which
         channel widths to scan for when re-registering after reboot.
 
+        Make-before-break: pass a LIST of bandwidths (current + new) so that the
+        SM can still re-register on the OLD bandwidth if the AP rolls back.
+
         Args:
             ip:        SM IP address.
-            width_mhz: Channel bandwidth in MHz (5, 7, 10, 15, 20, 30, 40).
+            width_mhz: Single bandwidth int (e.g. 20) OR list of ints (e.g. [15, 20]).
+                       Valid values: 5, 7, 10, 15, 20, 30, 40.
 
         Returns:
             Tuple (success: bool, message: str).
         """
         VALID_BWS = [5, 7, 10, 15, 20, 30, 40]
-        width_mhz = int(width_mhz)
-        if width_mhz not in VALID_BWS:
-            return False, (
-                f"Ancho de canal {width_mhz} MHz no soportado para SM. "
-                f"Válidos: {VALID_BWS}"
-            )
 
-        bw_str = f"{float(width_mhz):.1f} MHz"  # → "20.0 MHz"
+        # Normalise to list for uniform handling — backward compat with single int
+        if isinstance(width_mhz, list):
+            widths = [int(w) for w in width_mhz]
+        else:
+            widths = [int(width_mhz)]
+
+        for w in widths:
+            if w not in VALID_BWS:
+                return False, (
+                    f"Ancho de canal {w} MHz no soportado para SM. Válidos: {VALID_BWS}"
+                )
+
+        bw_str = ", ".join(
+            f"{float(w):.1f} MHz" for w in widths
+        )  # → "20.0 MHz" or "15.0 MHz, 20.0 MHz"
         self._log(
             f"[APPLY] {ip}: SET bandwidthScan = '{bw_str}' (OID {self.SM_BW_SCAN_OID})",
             "info",
@@ -980,6 +994,75 @@ class TowerScanner:
             self._log(f"[APPLY] {ip}: FALLÓ set_sm_bandwidth_scan — {msg}", "error")
 
         return success, msg
+
+    def get_sm_scan_list(self, ip: str) -> Tuple[bool, List[int], str]:
+        """GET current rfScanList.0 from SM via SNMP.
+
+        OID: .1.3.6.1.4.1.161.19.3.2.1.1.0 (RF_SCAN_LIST_OID, OctetString)
+        Response format: "3650000, 3660000" (frequencies in kHz, comma-separated).
+
+        Used by make-before-break strategy: read current scan list before merging
+        with the new frequency so that SM can still find the AP if it rolls back.
+
+        Args:
+            ip: SM IP address.
+
+        Returns:
+            Tuple (success: bool, freqs_khz: List[int], message: str).
+            On failure returns (False, [], error_message).
+        """
+        ok, raw, msg = self._snmp_get_oid(ip, self.RF_SCAN_LIST_OID)
+        if not ok:
+            self._log(
+                f"[APPLY] {ip}: GET rfScanList FAILED — {msg}",
+                "warning",
+            )
+            return False, [], msg
+
+        freqs = parse_scan_list(raw)
+        self._log(
+            f"[APPLY] {ip}: GET rfScanList = '{raw}' → {freqs}",
+            "info",
+        )
+        return True, freqs, "OK"
+
+    def get_sm_bandwidth_scan(self, ip: str) -> Tuple[bool, List[str], str]:
+        """GET current bandwidthScan.0 from SM via SNMP.
+
+        OID: .1.3.6.1.4.1.161.19.3.2.1.131.0 (SM_BW_SCAN_OID, OctetString)
+        Response format: "5.0 MHz, 20.0 MHz" (bandwidth strings, comma-separated).
+
+        Used by make-before-break strategy: read current bandwidth scan list before
+        merging with the new bandwidth so that SM can still re-register if AP rolls back.
+
+        Args:
+            ip: SM IP address.
+
+        Returns:
+            Tuple (success: bool, bws: List[str], message: str).
+            On failure returns (False, [], error_message).
+        """
+        ok, raw, msg = self._snmp_get_oid(ip, self.SM_BW_SCAN_OID)
+        if not ok:
+            self._log(
+                f"[APPLY] {ip}: GET bandwidthScan FAILED — {msg}",
+                "warning",
+            )
+            return False, [], msg
+
+        if not raw or not raw.strip():
+            self._log(
+                f"[APPLY] {ip}: GET bandwidthScan = '' (empty)",
+                "info",
+            )
+            return True, [], "OK"
+
+        bws = [part.strip() for part in raw.split(",") if part.strip()]
+        self._log(
+            f"[APPLY] {ip}: GET bandwidthScan = '{raw}' → {bws}",
+            "info",
+        )
+        return True, bws, "OK"
 
     def set_channel_width(
         self, ip: str, width_mhz: int, ap_freq_mhz: float = None

--- a/tests/test_freq_apply_manager.py
+++ b/tests/test_freq_apply_manager.py
@@ -43,6 +43,9 @@ def scanner():
     mock.set_broadcast_retry.return_value = (True, "OK")
     mock.reboot_if_required.return_value = (True, "OK")
     mock._snmp_get.return_value = (True, 5180000, "OK")
+    # Make-before-break GET stubs — return empty current config by default
+    mock.get_sm_scan_list.return_value = (True, [], "OK")
+    mock.get_sm_bandwidth_scan.return_value = (True, [], "OK")
     return mock
 
 
@@ -438,7 +441,7 @@ class TestBandwidthApply:
         assert call_order == ["bw", "rf"], f"Expected bw then rf, got: {call_order}"
 
     def test_bw_scan_passes_width_mhz(self, manager, db, scanner):
-        """GIVEN channel_width_mhz=30 THEN set_sm_bandwidth_scan receives 30."""
+        """GIVEN channel_width_mhz=30 and no current bw THEN set_sm_bandwidth_scan receives [30]."""
         _insert_scan(
             db,
             "BW2",
@@ -453,7 +456,9 @@ class TestBandwidthApply:
         )
 
         args, _ = scanner.set_sm_bandwidth_scan.call_args
-        assert args[1] == 30.0
+        # Make-before-break: receives list of ints (merged current + new)
+        # With empty current bws, merged = [30]
+        assert args[1] == [30]
 
     def test_bw_scan_not_called_when_no_channel_width(self, manager, db, scanner):
         """GIVEN channel_width_mhz=None THEN set_sm_bandwidth_scan is NOT called."""
@@ -563,3 +568,200 @@ class TestBandwidthApply:
 
         assert result["state"] == "completed"
         assert result["success"] is True
+
+
+# ── Make-Before-Break ─────────────────────────────────────────────────────────
+
+
+class TestMakeBeforeBreak:
+    """Tests for the make-before-break GET → merge → SET strategy in Step 2."""
+
+    def test_get_scan_list_called_before_set(self, manager, db, scanner):
+        """GIVEN SM with current freqs THEN get_sm_scan_list is called before set_sm_scan_list."""
+        call_order = []
+        scanner.get_sm_scan_list.side_effect = lambda *a, **kw: (
+            call_order.append("GET_RF"),
+            (True, [3650000], "OK"),
+        )[1]
+        scanner.set_sm_scan_list.side_effect = lambda *a, **kw: (
+            call_order.append("SET_RF"),
+            (True, "OK"),
+        )[1]
+
+        _insert_scan(
+            db,
+            "MBB1",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        manager.run_apply("MBB1", 3652.5, "TORRE-01", "admin", force=False)
+
+        assert call_order.index("GET_RF") < call_order.index("SET_RF"), (
+            "GET rfScanList must be called BEFORE SET rfScanList"
+        )
+
+    def test_get_bandwidth_scan_called_before_set(self, manager, db, scanner):
+        """GIVEN channel_width_mhz=20 THEN get_sm_bandwidth_scan called before set_sm_bandwidth_scan."""
+        call_order = []
+        scanner.get_sm_bandwidth_scan.side_effect = lambda *a, **kw: (
+            call_order.append("GET_BW"),
+            (True, ["15.0 MHz"], "OK"),
+        )[1]
+        scanner.set_sm_bandwidth_scan.side_effect = lambda *a, **kw: (
+            call_order.append("SET_BW"),
+            (True, "OK"),
+        )[1]
+
+        _insert_scan(
+            db,
+            "MBB2",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        manager.run_apply(
+            "MBB2", 3652.5, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
+        )
+
+        assert call_order.index("GET_BW") < call_order.index("SET_BW"), (
+            "GET bandwidthScan must be called BEFORE SET bandwidthScan"
+        )
+
+    def test_merged_freq_list_contains_both_current_and_new(self, manager, db, scanner):
+        """GIVEN current=[3650000] and new=3652500 THEN set_sm_scan_list receives [3650000, 3652500]."""
+        scanner.get_sm_scan_list.return_value = (True, [3650000], "OK")
+
+        _insert_scan(
+            db,
+            "MBB3",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        manager.run_apply("MBB3", 3652.5, "TORRE-01", "admin", force=False)
+
+        args, _ = scanner.set_sm_scan_list.call_args
+        merged = args[1]
+        assert 3650000 in merged, "Current freq must be in merged list"
+        assert 3652500 in merged, "New freq must be in merged list"
+
+    def test_get_failure_falls_back_to_new_only(self, manager, db, scanner):
+        """GIVEN GET rfScanList fails THEN set_sm_scan_list receives only the new frequency."""
+        scanner.get_sm_scan_list.return_value = (False, [], "Timeout")
+
+        _insert_scan(
+            db,
+            "MBB4",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        result = manager.run_apply("MBB4", 3652.5, "TORRE-01", "admin", force=False)
+
+        # Apply must still succeed (GET failure is non-fatal)
+        assert result["state"] == "completed"
+        args, _ = scanner.set_sm_scan_list.call_args
+        merged = args[1]
+        assert merged == [3652500], f"Expected [3652500] on GET failure, got {merged}"
+
+    def test_deduplication_when_new_freq_already_in_current(self, manager, db, scanner):
+        """GIVEN current=[3652500] and new=3652500 THEN merged list has no duplicate."""
+        scanner.get_sm_scan_list.return_value = (True, [3652500], "OK")
+
+        _insert_scan(
+            db,
+            "MBB5",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        manager.run_apply("MBB5", 3652.5, "TORRE-01", "admin", force=False)
+
+        args, _ = scanner.set_sm_scan_list.call_args
+        merged = args[1]
+        assert merged.count(3652500) == 1, f"Duplicate found: {merged}"
+
+    def test_merged_bw_contains_both_current_and_new(self, manager, db, scanner):
+        """GIVEN current bw=['15.0 MHz'] and new=20 THEN set_sm_bandwidth_scan receives [15, 20]."""
+        scanner.get_sm_bandwidth_scan.return_value = (True, ["15.0 MHz"], "OK")
+
+        _insert_scan(
+            db,
+            "MBB6",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        manager.run_apply(
+            "MBB6", 3652.5, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
+        )
+
+        args, _ = scanner.set_sm_bandwidth_scan.call_args
+        merged_bws = args[1]
+        assert 15 in merged_bws, "Current bw (15) must be in merged list"
+        assert 20 in merged_bws, "New bw (20) must be in merged list"
+
+    def test_bw_get_failure_falls_back_to_new_only(self, manager, db, scanner):
+        """GIVEN GET bandwidthScan fails THEN set_sm_bandwidth_scan receives only [new_bw]."""
+        scanner.get_sm_bandwidth_scan.return_value = (False, [], "Timeout")
+
+        _insert_scan(
+            db,
+            "MBB7",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        result = manager.run_apply(
+            "MBB7", 3652.5, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
+        )
+
+        assert result["state"] == "completed"
+        args, _ = scanner.set_sm_bandwidth_scan.call_args
+        assert args[1] == [20], f"Expected [20] on GET failure, got {args[1]}"
+
+    def test_full_flow_get_merge_set(self, manager, db, scanner):
+        """GIVEN full make-before-break flow THEN state is 'completed' with merged values sent."""
+        scanner.get_sm_scan_list.return_value = (True, [3650000], "OK")
+        scanner.get_sm_bandwidth_scan.return_value = (True, ["15.0 MHz"], "OK")
+
+        _insert_scan(
+            db,
+            "MBB8",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        result = manager.run_apply(
+            "MBB8", 3652.5, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
+        )
+
+        assert result["state"] == "completed"
+        assert result["success"] is True
+
+        # rfScanList: should have merged [3650000, 3652500]
+        rf_args, _ = scanner.set_sm_scan_list.call_args
+        assert 3650000 in rf_args[1]
+        assert 3652500 in rf_args[1]
+
+        # bandwidthScan: should have merged [15, 20]
+        bw_args, _ = scanner.set_sm_bandwidth_scan.call_args
+        assert 15 in bw_args[1]
+        assert 20 in bw_args[1]

--- a/tests/test_tower_scan_set.py
+++ b/tests/test_tower_scan_set.py
@@ -263,3 +263,198 @@ class TestSetSmBandwidthScan:
             with patch.object(scanner, "_log") as mock_log:
                 scanner.set_sm_bandwidth_scan("192.168.1.20", 20)
                 assert mock_log.called
+
+    def test_accepts_list_of_bandwidths(self, scanner):
+        """GIVEN [15, 20] THEN value is '15.0 MHz, 20.0 MHz' (make-before-break)."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
+            success, _ = scanner.set_sm_bandwidth_scan("192.168.1.20", [15, 20])
+        assert success is True
+        _, kwargs = mock_set.call_args
+        assert kwargs.get("value") == "15.0 MHz, 20.0 MHz"
+
+    def test_list_single_element_same_as_scalar(self, scanner):
+        """GIVEN [20] (list with one element) THEN value is '20.0 MHz' (backward compat)."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
+            success, _ = scanner.set_sm_bandwidth_scan("192.168.1.20", [20])
+        assert success is True
+        _, kwargs = mock_set.call_args
+        assert kwargs.get("value") == "20.0 MHz"
+
+    def test_list_invalid_bw_returns_error(self, scanner):
+        """GIVEN [20, 99] (99 is invalid) THEN returns (False, error) without SNMP call."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
+            success, msg = scanner.set_sm_bandwidth_scan("192.168.1.20", [20, 99])
+        assert success is False
+        assert "99" in msg
+        mock_set.assert_not_called()
+
+    def test_scalar_backward_compat_still_works(self, scanner):
+        """GIVEN scalar int 30 THEN behaves exactly as before (backward compat)."""
+        with patch.object(
+            scanner, "_snmp_set_string", return_value=(True, "OK")
+        ) as mock_set:
+            success, _ = scanner.set_sm_bandwidth_scan("192.168.1.20", 30)
+        assert success is True
+        _, kwargs = mock_set.call_args
+        assert kwargs.get("value") == "30.0 MHz"
+
+
+# ── get_sm_scan_list() ────────────────────────────────────────────────────────
+
+
+class TestGetSmScanList:
+    """Tests for TowerScanner.get_sm_scan_list() — rfScanList GET via _snmp_get_oid()."""
+
+    def test_returns_parsed_freq_list_on_success(self, scanner):
+        """GIVEN SNMP GET returns '3650000, 3660000' THEN returns (True, [3650000, 3660000], 'OK')."""
+        with patch.object(
+            scanner, "_snmp_get_oid", return_value=(True, "3650000, 3660000", "OK")
+        ):
+            ok, freqs, msg = scanner.get_sm_scan_list("192.168.1.20")
+        assert ok is True
+        assert freqs == [3650000, 3660000]
+        assert msg == "OK"
+
+    def test_returns_empty_list_on_snmp_failure(self, scanner):
+        """GIVEN SNMP GET fails THEN returns (False, [], error_msg)."""
+        with patch.object(
+            scanner, "_snmp_get_oid", return_value=(False, "", "Timeout")
+        ):
+            ok, freqs, msg = scanner.get_sm_scan_list("192.168.1.20")
+        assert ok is False
+        assert freqs == []
+        assert "Timeout" in msg
+
+    def test_parses_single_frequency(self, scanner):
+        """GIVEN SNMP GET returns '3650000' THEN returns [3650000]."""
+        with patch.object(
+            scanner, "_snmp_get_oid", return_value=(True, "3650000", "OK")
+        ):
+            ok, freqs, msg = scanner.get_sm_scan_list("192.168.1.20")
+        assert ok is True
+        assert freqs == [3650000]
+
+    def test_parses_multiple_frequencies(self, scanner):
+        """GIVEN '3647500, 3650000, 3652500' THEN returns list of 3 ints."""
+        with patch.object(
+            scanner,
+            "_snmp_get_oid",
+            return_value=(True, "3647500, 3650000, 3652500", "OK"),
+        ):
+            ok, freqs, _ = scanner.get_sm_scan_list("192.168.1.20")
+        assert freqs == [3647500, 3650000, 3652500]
+
+    def test_handles_empty_response(self, scanner):
+        """GIVEN SNMP GET returns empty string THEN returns (True, [], 'OK')."""
+        with patch.object(scanner, "_snmp_get_oid", return_value=(True, "", "OK")):
+            ok, freqs, msg = scanner.get_sm_scan_list("192.168.1.20")
+        assert ok is True
+        assert freqs == []
+
+    def test_handles_whitespace_only_response(self, scanner):
+        """GIVEN SNMP GET returns whitespace THEN returns (True, [], 'OK')."""
+        with patch.object(scanner, "_snmp_get_oid", return_value=(True, "   ", "OK")):
+            ok, freqs, _ = scanner.get_sm_scan_list("192.168.1.20")
+        assert freqs == []
+
+    def test_uses_rf_scan_list_oid(self, scanner):
+        """GIVEN get_sm_scan_list THEN _snmp_get_oid is called with RF_SCAN_LIST_OID."""
+        with patch.object(
+            scanner, "_snmp_get_oid", return_value=(True, "3650000", "OK")
+        ) as mock_get:
+            scanner.get_sm_scan_list("192.168.1.20")
+        _, call_args = mock_get.call_args
+        # _snmp_get_oid(ip, oid) — oid is positional arg [1]
+        positional = mock_get.call_args.args
+        assert positional[1] == TowerScanner.RF_SCAN_LIST_OID
+
+    def test_passes_correct_ip(self, scanner):
+        """GIVEN IP '10.0.0.5' THEN _snmp_get_oid is called with that IP."""
+        with patch.object(
+            scanner, "_snmp_get_oid", return_value=(True, "3650000", "OK")
+        ) as mock_get:
+            scanner.get_sm_scan_list("10.0.0.5")
+        positional = mock_get.call_args.args
+        assert positional[0] == "10.0.0.5"
+
+
+# ── get_sm_bandwidth_scan() ───────────────────────────────────────────────────
+
+
+class TestGetSmBandwidthScan:
+    """Tests for TowerScanner.get_sm_bandwidth_scan() — bandwidthScan GET via _snmp_get_oid()."""
+
+    def test_returns_parsed_bw_list_on_success(self, scanner):
+        """GIVEN SNMP GET returns '5.0 MHz, 20.0 MHz' THEN returns (True, ['5.0 MHz', '20.0 MHz'], 'OK')."""
+        with patch.object(
+            scanner, "_snmp_get_oid", return_value=(True, "5.0 MHz, 20.0 MHz", "OK")
+        ):
+            ok, bws, msg = scanner.get_sm_bandwidth_scan("192.168.1.20")
+        assert ok is True
+        assert bws == ["5.0 MHz", "20.0 MHz"]
+        assert msg == "OK"
+
+    def test_returns_empty_list_on_snmp_failure(self, scanner):
+        """GIVEN SNMP GET fails THEN returns (False, [], error_msg)."""
+        with patch.object(
+            scanner, "_snmp_get_oid", return_value=(False, "", "No SNMP response")
+        ):
+            ok, bws, msg = scanner.get_sm_bandwidth_scan("192.168.1.20")
+        assert ok is False
+        assert bws == []
+
+    def test_parses_single_bandwidth(self, scanner):
+        """GIVEN SNMP GET returns '20.0 MHz' THEN returns ['20.0 MHz']."""
+        with patch.object(
+            scanner, "_snmp_get_oid", return_value=(True, "20.0 MHz", "OK")
+        ):
+            ok, bws, _ = scanner.get_sm_bandwidth_scan("192.168.1.20")
+        assert ok is True
+        assert bws == ["20.0 MHz"]
+
+    def test_parses_multiple_bandwidths(self, scanner):
+        """GIVEN '10.0 MHz, 15.0 MHz, 20.0 MHz' THEN returns list of 3 strings."""
+        with patch.object(
+            scanner,
+            "_snmp_get_oid",
+            return_value=(True, "10.0 MHz, 15.0 MHz, 20.0 MHz", "OK"),
+        ):
+            ok, bws, _ = scanner.get_sm_bandwidth_scan("192.168.1.20")
+        assert bws == ["10.0 MHz", "15.0 MHz", "20.0 MHz"]
+
+    def test_handles_empty_response(self, scanner):
+        """GIVEN SNMP GET returns empty string THEN returns (True, [], 'OK')."""
+        with patch.object(scanner, "_snmp_get_oid", return_value=(True, "", "OK")):
+            ok, bws, msg = scanner.get_sm_bandwidth_scan("192.168.1.20")
+        assert ok is True
+        assert bws == []
+
+    def test_handles_whitespace_only_response(self, scanner):
+        """GIVEN SNMP GET returns whitespace THEN returns (True, [], 'OK')."""
+        with patch.object(scanner, "_snmp_get_oid", return_value=(True, "  ", "OK")):
+            ok, bws, _ = scanner.get_sm_bandwidth_scan("192.168.1.20")
+        assert bws == []
+
+    def test_uses_sm_bw_scan_oid(self, scanner):
+        """GIVEN get_sm_bandwidth_scan THEN _snmp_get_oid is called with SM_BW_SCAN_OID."""
+        with patch.object(
+            scanner, "_snmp_get_oid", return_value=(True, "20.0 MHz", "OK")
+        ) as mock_get:
+            scanner.get_sm_bandwidth_scan("192.168.1.20")
+        positional = mock_get.call_args.args
+        assert positional[1] == TowerScanner.SM_BW_SCAN_OID
+
+    def test_passes_correct_ip(self, scanner):
+        """GIVEN IP '10.0.0.7' THEN _snmp_get_oid is called with that IP."""
+        with patch.object(
+            scanner, "_snmp_get_oid", return_value=(True, "20.0 MHz", "OK")
+        ) as mock_get:
+            scanner.get_sm_bandwidth_scan("10.0.0.7")
+        positional = mock_get.call_args.args
+        assert positional[0] == "10.0.0.7"


### PR DESCRIPTION
### Type
- [x] Bug fix

### Summary
Implements a **make-before-break** strategy for SM frequency/bandwidth apply to prevent SM orphaning when AP rolls back (DFS, noise, hardware failure).

**Before**: `rfScanList` and `bandwidthScan` were **replaced** with only the new values → if AP rolls back, SMs can't find it.

**After**: Current SM config is **read first** (SNMP GET), then **merged** with new values (deduplicated) → SMs always retain the current frequency/bandwidth alongside the new one.

### Changes

| File | Change |
|------|--------|
| `app/tower_scan.py` | Added `get_sm_scan_list()` + `get_sm_bandwidth_scan()` GET methods; `set_sm_bandwidth_scan()` now accepts `List[int]` |
| `app/freq_apply_manager.py` | Step 2: GET current → merge → SET merged (per SM); graceful fallback on GET failure |
| `tests/test_tower_scan_set.py` | +20 new tests: `TestGetSmScanList` (8), `TestGetSmBandwidthScan` (8), multi-BW SET (4) |
| `tests/test_freq_apply_manager.py` | +8 new tests: `TestMakeBeforeBreak` class |

### Test Plan
- [x] `py -3.13 -m pytest tests/test_tower_scan_set.py tests/test_freq_apply_manager.py -v` — **74/74 pass**
- [x] Full suite: 587 passed, 9 pre-existing failures (unrelated)

### Safety Notes
- GET failures are **non-fatal** — falls back to previous behavior (new values only)
- Cleanup phase (removing old values after confirmed re-registration) is deferred to a separate change