### PR TITLE
fix(apply): harden make-before-break — SM timeouts, audit tracking, BW dedup, scan list cap

### DIFF
--- a/app/freq_apply_manager.py
+++ b/app/freq_apply_manager.py
@@ -47,6 +47,9 @@ logger = logging.getLogger(__name__)
 # Minimum combined_score required for auto-apply and un-forced manual apply.
 _VIABILITY_SCORE_THRESHOLD = 0.65
 
+# Maximum number of entries kept in the SM rfScanList after merging (firmware limit).
+SM_SCAN_LIST_MAX_ENTRIES = 8
+
 
 class FrequencyApplyManager:
     """Orchestrates the SM-first → AP-last frequency apply sequence.
@@ -216,6 +219,7 @@ class FrequencyApplyManager:
         # Si falla rfScanList → SM se marca como fallido.
         sm_results: Dict[str, Dict] = {}
         sm_failures: List[str] = []
+        sm_skipped: List[str] = []
 
         if sm_ips:
             for sm_ip in sm_ips:
@@ -226,19 +230,29 @@ class FrequencyApplyManager:
                 # merge (not replace) — if AP rolls back, SM can still find it.
 
                 # 2a. GET current rfScanList (best-effort, non-fatal on failure)
+                # If GET fails we SKIP the SET entirely — writing new-only would destroy
+                # the SM's existing scan list and that is exactly what make-before-break
+                # was designed to prevent (rollback safety).
                 get_ok, current_freqs, get_msg = self._scanner.get_sm_scan_list(sm_ip)
                 if not get_ok:
                     logger.warning(
-                        "[APPLY %d] SM %s: GET rfScanList failed (non-fatal) — %s. "
-                        "Falling back to new-only.",
+                        "[APPLY %d] SM %s: skipping rfScanList mutation — could not read "
+                        "current config (rollback safety): %s",
                         apply_id,
                         sm_ip,
                         get_msg,
                     )
-                    current_freqs = []
+                    sm_entry["skipped_preservation"] = True
+                    sm_results[sm_ip] = sm_entry
+                    sm_skipped.append(sm_ip)
+                    errors.append(
+                        f"SM {sm_ip}: skipped — could not read current scan list for preservation"
+                    )
+                    continue  # Skip this SM entirely — AP will still be changed below
 
-                # Merge: deduplicated union of current + new frequency
+                # Merge: deduplicated union of current + new frequency, capped to max entries
                 merged_freqs = list(dict.fromkeys(current_freqs + [freq_khz]))
+                merged_freqs = merged_freqs[-SM_SCAN_LIST_MAX_ENTRIES:]
                 logger.info(
                     "[APPLY] SM %s: merging rfScanList: current=%s + new=%s → merged=%s",
                     sm_ip,
@@ -248,66 +262,82 @@ class FrequencyApplyManager:
                 )
 
                 # 2b. GET current bandwidthScan (best-effort, non-fatal on failure)
+                # If GET fails, skip SET for bandwidthScan too (same rollback-safety logic).
                 if channel_width:
                     bw_get_ok, current_bws, bw_get_msg = (
                         self._scanner.get_sm_bandwidth_scan(sm_ip)
                     )
                     if not bw_get_ok:
                         logger.warning(
-                            "[APPLY %d] SM %s: GET bandwidthScan failed (non-fatal) — %s. "
-                            "Falling back to new-only.",
+                            "[APPLY %d] SM %s: skipping bandwidthScan mutation — could not "
+                            "read current config (rollback safety): %s",
                             apply_id,
                             sm_ip,
                             bw_get_msg,
                         )
-                        current_bws = []
+                        sm_entry["bw_scan"] = {"skipped_preservation": True}
+                    else:
+                        new_bw_str = f"{float(channel_width):.1f} MHz"
 
-                    new_bw_str = f"{float(channel_width):.1f} MHz"
-                    # Merge: deduplicated union of current + new bandwidth strings
-                    merged_bws_str = list(dict.fromkeys(current_bws + [new_bw_str]))
-                    logger.info(
-                        "[APPLY] SM %s: merging bandwidthScan: current=%s + new=%s → merged=%s",
-                        sm_ip,
-                        current_bws,
-                        [new_bw_str],
-                        merged_bws_str,
-                    )
+                        # Normalize current_bws to canonical "X.0 MHz" form before
+                        # deduplication — firmware may return "20 MHz" (no decimal)
+                        # while new_bw_str is "20.0 MHz", causing silent duplicates.
+                        def _normalize_bw(s: str) -> str:
+                            try:
+                                return f"{float(s.replace('MHz', '').strip()):.1f} MHz"
+                            except (ValueError, AttributeError):
+                                return s
 
-                    # Convert merged bandwidth strings back to int list for the setter
-                    # e.g. ["15.0 MHz", "20.0 MHz"] → [15, 20]
-                    merged_bws_int = []
-                    for bw_s in merged_bws_str:
-                        try:
-                            merged_bws_int.append(
-                                int(float(bw_s.replace("MHz", "").strip()))
-                            )
-                        except ValueError:
-                            pass  # Skip malformed values
-
-                    # 2c. SET bandwidthScan with merged list
-                    bw_ok, bw_msg = self._scanner.set_sm_bandwidth_scan(
-                        sm_ip, merged_bws_int
-                    )
-                    sm_entry["bw_scan"] = {
-                        "success": bw_ok,
-                        "error": bw_msg if not bw_ok else None,
-                    }
-                    if bw_ok:
+                        normalized_current = [_normalize_bw(b) for b in current_bws]
+                        normalized_new = _normalize_bw(new_bw_str)
+                        # Merge: deduplicated union of current + new bandwidth strings, capped
+                        merged_bws_str = list(
+                            dict.fromkeys(normalized_current + [normalized_new])
+                        )
+                        merged_bws_str = merged_bws_str[-SM_SCAN_LIST_MAX_ENTRIES:]
                         logger.info(
-                            "[APPLY %d] SM %s: bandwidthScan=%s OK",
-                            apply_id,
+                            "[APPLY] SM %s: merging bandwidthScan: current=%s + new=%s → merged=%s",
                             sm_ip,
+                            current_bws,
+                            [new_bw_str],
                             merged_bws_str,
                         )
-                    else:
-                        # Non-fatal: SM puede seguir con rfScanList
-                        errors.append(f"SM {sm_ip} bandwidthScan: {bw_msg}")
-                        logger.warning(
-                            "[APPLY %d] SM %s bandwidthScan failed (non-fatal): %s",
-                            apply_id,
-                            sm_ip,
-                            bw_msg,
+
+                        # Convert merged bandwidth strings back to int list for the setter
+                        # e.g. ["15.0 MHz", "20.0 MHz"] → [15, 20]
+                        merged_bws_int = []
+                        for bw_s in merged_bws_str:
+                            try:
+                                merged_bws_int.append(
+                                    int(float(bw_s.replace("MHz", "").strip()))
+                                )
+                            except ValueError:
+                                pass  # Skip malformed values
+
+                        # 2c. SET bandwidthScan with merged list
+                        bw_ok, bw_msg = self._scanner.set_sm_bandwidth_scan(
+                            sm_ip, merged_bws_int
                         )
+                        sm_entry["bw_scan"] = {
+                            "success": bw_ok,
+                            "error": bw_msg if not bw_ok else None,
+                        }
+                        if bw_ok:
+                            logger.info(
+                                "[APPLY %d] SM %s: bandwidthScan=%s OK",
+                                apply_id,
+                                sm_ip,
+                                merged_bws_str,
+                            )
+                        else:
+                            # Non-fatal: SM puede seguir con rfScanList
+                            errors.append(f"SM {sm_ip} bandwidthScan: {bw_msg}")
+                            logger.warning(
+                                "[APPLY %d] SM %s bandwidthScan failed (non-fatal): %s",
+                                apply_id,
+                                sm_ip,
+                                bw_msg,
+                            )
 
                 # 2d. SET rfScanList with merged list (frecuencia — siempre)
                 success, msg = self._scanner.set_sm_scan_list(sm_ip, merged_freqs)
@@ -446,6 +476,7 @@ class FrequencyApplyManager:
             final_state=final_state,
             sm_count=len(sm_ips),
             failed_sm_count=len(sm_failures),
+            skipped_sm_count=len(sm_skipped),
             ap_success=ap_success,
             errors=errors,
         )
@@ -530,6 +561,7 @@ class FrequencyApplyManager:
         final_state: str,
         sm_count: int,
         failed_sm_count: int,
+        skipped_sm_count: int,
         ap_success: bool,
         errors: List[str],
     ) -> None:
@@ -542,7 +574,7 @@ class FrequencyApplyManager:
             )
             result_summary = (
                 f"apply_id={apply_id} state={final_state} "
-                f"freq={freq_khz}kHz sm={sm_count}(failed={failed_sm_count}) "
+                f"freq={freq_khz}kHz sm={sm_count}(failed={failed_sm_count},skipped={skipped_sm_count}) "
                 f"ap={'OK' if ap_success else 'FAILED'}"
             )
             audit.log_action(
@@ -555,6 +587,7 @@ class FrequencyApplyManager:
                     "state": final_state,
                     "sm_count": sm_count,
                     "failed_sm_count": failed_sm_count,
+                    "skipped_sm_count": skipped_sm_count,
                     "ap_success": ap_success,
                     "errors": errors,
                 },

--- a/app/tower_scan.py
+++ b/app/tower_scan.py
@@ -753,16 +753,14 @@ class TowerScanner:
         return results
 
     def _snmp_get_oid_raw(
-        self, ip: str, oid: str, community: str
+        self, ip: str, oid: str, community: str, timeout: int = 5, retries: int = 2
     ) -> Tuple[bool, str, str]:
         """Helper para probar una comunidad específica"""
         try:
             iterator = getCmd(
                 SnmpEngine(),
                 CommunityData(community, mpModel=1),
-                UdpTransportTarget(
-                    (ip, 161), timeout=5, retries=2
-                ),  # Timeout aumentado a 5s, 2 retries
+                UdpTransportTarget((ip, 161), timeout=timeout, retries=retries),
                 ContextData(),
                 ObjectType(ObjectIdentity(oid)),
             )
@@ -781,7 +779,9 @@ class TowerScanner:
     ) -> Tuple[bool, str, str]:
         """Helper genérico para GET OID usando la comunidad mapeada"""
         community = self._get_community(ip)
-        return self._snmp_get_oid_raw(ip, oid, community)
+        return self._snmp_get_oid_raw(
+            ip, oid, community, timeout=timeout, retries=retries
+        )
 
     # =========================================================================
     # MÉTODOS DE APPLY DE FRECUENCIA (change-006)
@@ -929,6 +929,8 @@ class TowerScanner:
             ip=ip,
             oid=self.RF_SCAN_LIST_OID,
             value=scan_list_str,
+            timeout=self.SM_SNMP_TIMEOUT,
+            retries=self.SM_SNMP_RETRIES,
         )
 
         if success:
@@ -986,6 +988,8 @@ class TowerScanner:
             ip=ip,
             oid=self.SM_BW_SCAN_OID,
             value=bw_str,
+            timeout=self.SM_SNMP_TIMEOUT,
+            retries=self.SM_SNMP_RETRIES,
         )
 
         if success:
@@ -994,6 +998,41 @@ class TowerScanner:
             self._log(f"[APPLY] {ip}: FALLÓ set_sm_bandwidth_scan — {msg}", "error")
 
         return success, msg
+
+    def _snmp_get_oid_sm(self, ip: str, oid: str) -> Tuple[bool, str, str]:
+        """GET an OctetString OID from a SM, trying ALL communities until one succeeds.
+
+        Unlike _snmp_get_oid() (which uses a single mapped community), this helper
+        iterates self.snmp_communities so it works even when device_community_map is
+        empty — e.g. when FrequencyApplyManager creates a scanner without running
+        the full discovery/validation flow first (Issue #2).
+
+        Uses SM_SNMP_TIMEOUT and SM_SNMP_RETRIES (Issue #3) — SMs have higher
+        latency than APs so the AP-level 2-second timeout is insufficient.
+
+        Args:
+            ip:  SM IP address.
+            oid: OID to GET (OctetString expected).
+
+        Returns:
+            Tuple (success: bool, raw_value: str, message: str).
+            On all-communities failure returns (False, '', "all communities failed").
+        """
+        last_msg = "no communities configured"
+        for community in self.snmp_communities:
+            ok, raw, msg = self._snmp_get_oid_raw(
+                ip,
+                oid,
+                community,
+                timeout=self.SM_SNMP_TIMEOUT,
+                retries=self.SM_SNMP_RETRIES,
+            )
+            if ok:
+                return True, raw, "OK"
+            last_msg = msg
+
+        # All communities exhausted
+        return False, "", f"all communities failed: {last_msg}"
 
     def get_sm_scan_list(self, ip: str) -> Tuple[bool, List[int], str]:
         """GET current rfScanList.0 from SM via SNMP.
@@ -1004,6 +1043,10 @@ class TowerScanner:
         Used by make-before-break strategy: read current scan list before merging
         with the new frequency so that SM can still find the AP if it rolls back.
 
+        Tries ALL configured SNMP communities (not just the mapped one) so it works
+        correctly even when device_community_map is empty (Issue #2).
+        Uses SM_SNMP_TIMEOUT / SM_SNMP_RETRIES for higher-latency SM links (Issue #3).
+
         Args:
             ip: SM IP address.
 
@@ -1011,7 +1054,7 @@ class TowerScanner:
             Tuple (success: bool, freqs_khz: List[int], message: str).
             On failure returns (False, [], error_message).
         """
-        ok, raw, msg = self._snmp_get_oid(ip, self.RF_SCAN_LIST_OID)
+        ok, raw, msg = self._snmp_get_oid_sm(ip, self.RF_SCAN_LIST_OID)
         if not ok:
             self._log(
                 f"[APPLY] {ip}: GET rfScanList FAILED — {msg}",
@@ -1019,7 +1062,12 @@ class TowerScanner:
             )
             return False, [], msg
 
-        freqs = parse_scan_list(raw)
+        try:
+            freqs = parse_scan_list(raw)
+        except Exception as exc:
+            err = f"parse_scan_list failed: {exc}"
+            self._log(f"[APPLY] {ip}: GET rfScanList parse error — {err}", "warning")
+            return False, [], err
         self._log(
             f"[APPLY] {ip}: GET rfScanList = '{raw}' → {freqs}",
             "info",
@@ -1035,6 +1083,10 @@ class TowerScanner:
         Used by make-before-break strategy: read current bandwidth scan list before
         merging with the new bandwidth so that SM can still re-register if AP rolls back.
 
+        Tries ALL configured SNMP communities (not just the mapped one) so it works
+        correctly even when device_community_map is empty (Issue #2).
+        Uses SM_SNMP_TIMEOUT / SM_SNMP_RETRIES for higher-latency SM links (Issue #3).
+
         Args:
             ip: SM IP address.
 
@@ -1042,7 +1094,7 @@ class TowerScanner:
             Tuple (success: bool, bws: List[str], message: str).
             On failure returns (False, [], error_message).
         """
-        ok, raw, msg = self._snmp_get_oid(ip, self.SM_BW_SCAN_OID)
+        ok, raw, msg = self._snmp_get_oid_sm(ip, self.SM_BW_SCAN_OID)
         if not ok:
             self._log(
                 f"[APPLY] {ip}: GET bandwidthScan FAILED — {msg}",

--- a/tests/test_freq_apply_manager.py
+++ b/tests/test_freq_apply_manager.py
@@ -652,8 +652,13 @@ class TestMakeBeforeBreak:
         assert 3650000 in merged, "Current freq must be in merged list"
         assert 3652500 in merged, "New freq must be in merged list"
 
-    def test_get_failure_falls_back_to_new_only(self, manager, db, scanner):
-        """GIVEN GET rfScanList fails THEN set_sm_scan_list receives only the new frequency."""
+    def test_get_failure_skips_sm_mutation(self, manager, db, scanner):
+        """GIVEN GET rfScanList fails THEN set_sm_scan_list is NOT called for that SM.
+
+        Rollback safety: writing new-only would destroy the SM's existing scan list.
+        When we can't read the current list, the safe choice is to leave the SM as-is.
+        The SM keeps its current config; only the AP frequency changes.
+        """
         scanner.get_sm_scan_list.return_value = (False, [], "Timeout")
 
         _insert_scan(
@@ -667,11 +672,10 @@ class TestMakeBeforeBreak:
         )
         result = manager.run_apply("MBB4", 3652.5, "TORRE-01", "admin", force=False)
 
-        # Apply must still succeed (GET failure is non-fatal)
-        assert result["state"] == "completed"
-        args, _ = scanner.set_sm_scan_list.call_args
-        merged = args[1]
-        assert merged == [3652500], f"Expected [3652500] on GET failure, got {merged}"
+        # The SM's rfScanList must NOT have been touched (rollback safety)
+        scanner.set_sm_scan_list.assert_not_called()
+        # The skipped SM is reflected in results with skipped_preservation flag
+        assert result["sm_results"]["192.168.1.20"].get("skipped_preservation") is True
 
     def test_deduplication_when_new_freq_already_in_current(self, manager, db, scanner):
         """GIVEN current=[3652500] and new=3652500 THEN merged list has no duplicate."""
@@ -714,8 +718,16 @@ class TestMakeBeforeBreak:
         assert 15 in merged_bws, "Current bw (15) must be in merged list"
         assert 20 in merged_bws, "New bw (20) must be in merged list"
 
-    def test_bw_get_failure_falls_back_to_new_only(self, manager, db, scanner):
-        """GIVEN GET bandwidthScan fails THEN set_sm_bandwidth_scan receives only [new_bw]."""
+    def test_bw_get_failure_skips_sm_bw_mutation(self, manager, db, scanner):
+        """GIVEN GET bandwidthScan fails THEN set_sm_bandwidth_scan is NOT called for that SM.
+
+        Rollback safety: writing new-only bandwidth would destroy the SM's existing
+        bandwidth scan list. When we can't read the current list, we skip the SET.
+        The rfScanList SET still proceeds (its GET succeeded).
+        """
+        # rfScanList GET succeeds (so rfScanList SET will proceed)
+        scanner.get_sm_scan_list.return_value = (True, [], "OK")
+        # bandwidthScan GET fails → must skip bandwidthScan SET
         scanner.get_sm_bandwidth_scan.return_value = (False, [], "Timeout")
 
         _insert_scan(
@@ -731,9 +743,15 @@ class TestMakeBeforeBreak:
             "MBB7", 3652.5, "TORRE-01", "admin", force=False, channel_width_mhz=20.0
         )
 
-        assert result["state"] == "completed"
-        args, _ = scanner.set_sm_bandwidth_scan.call_args
-        assert args[1] == [20], f"Expected [20] on GET failure, got {args[1]}"
+        # bandwidthScan must NOT have been touched (rollback safety)
+        scanner.set_sm_bandwidth_scan.assert_not_called()
+        # rfScanList SET should still have been called (its GET succeeded)
+        scanner.set_sm_scan_list.assert_called_once()
+        # The apply state reflects the bw_scan was skipped
+        assert (
+            result["sm_results"]["192.168.1.20"]["bw_scan"].get("skipped_preservation")
+            is True
+        )
 
     def test_full_flow_get_merge_set(self, manager, db, scanner):
         """GIVEN full make-before-break flow THEN state is 'completed' with merged values sent."""
@@ -765,3 +783,51 @@ class TestMakeBeforeBreak:
         bw_args, _ = scanner.set_sm_bandwidth_scan.call_args
         assert 15 in bw_args[1]
         assert 20 in bw_args[1]
+
+    def test_get_failure_logs_preservation_warning(self, manager, db, scanner, caplog):
+        """GIVEN GET rfScanList fails THEN a warning about skipping is logged."""
+        import logging
+
+        scanner.get_sm_scan_list.return_value = (False, [], "No SNMP response")
+
+        _insert_scan(
+            db,
+            "MBB9",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        with caplog.at_level(logging.WARNING, logger="app.freq_apply_manager"):
+            manager.run_apply("MBB9", 3652.5, "TORRE-01", "admin", force=False)
+
+        # Must log a warning that mentions skipping and rollback safety
+        warning_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any(
+            "skipping rfScanList mutation" in m and "rollback safety" in m
+            for m in warning_msgs
+        ), f"Expected preservation warning in logs, got: {warning_msgs}"
+
+    def test_get_failure_does_not_prevent_ap_apply(self, manager, db, scanner):
+        """GIVEN GET rfScanList fails for SM THEN the AP frequency change still happens."""
+        scanner.get_sm_scan_list.return_value = (False, [], "Timeout")
+
+        _insert_scan(
+            db,
+            "MBB10",
+            ["192.168.1.10"],
+            sm_ips=["192.168.1.20"],
+            results={
+                "best_combined_frequency": {"is_viable": True, "combined_score": 0.90}
+            },
+        )
+        result = manager.run_apply("MBB10", 3652.5, "TORRE-01", "admin", force=False)
+
+        # AP SET must still have been called with the target frequency
+        scanner.set_frequency.assert_called_once_with("192.168.1.10", 3652500)
+        # Apply succeeds (AP succeeded; SM was skipped, not failed)
+        assert result["state"] == "completed"
+        assert result["ap_result"]["success"] is True

--- a/tests/test_tower_scan_set.py
+++ b/tests/test_tower_scan_set.py
@@ -119,12 +119,19 @@ class TestSetSmScanList:
     """Tests for TowerScanner.set_sm_scan_list() — rfScanList via _snmp_set_string()."""
 
     def test_delegates_to_snmp_set_string(self, scanner):
-        """GIVEN set_sm_scan_list call THEN _snmp_set_string is called once."""
+        """GIVEN set_sm_scan_list call THEN _snmp_set_string is called once with SM timeouts."""
         with patch.object(
             scanner, "_snmp_set_string", return_value=(True, "OK")
         ) as mock_set:
             scanner.set_sm_scan_list("192.168.1.20", [5180000])
         mock_set.assert_called_once()
+        _, kwargs = mock_set.call_args
+        assert kwargs.get("timeout") == TowerScanner.SM_SNMP_TIMEOUT, (
+            f"Expected SM_SNMP_TIMEOUT={TowerScanner.SM_SNMP_TIMEOUT}, got {kwargs.get('timeout')}"
+        )
+        assert kwargs.get("retries") == TowerScanner.SM_SNMP_RETRIES, (
+            f"Expected SM_SNMP_RETRIES={TowerScanner.SM_SNMP_RETRIES}, got {kwargs.get('retries')}"
+        )
 
     def test_passes_rf_scan_list_oid(self, scanner):
         """GIVEN set_sm_scan_list THEN _snmp_set_string receives RF_SCAN_LIST_OID."""
@@ -190,12 +197,19 @@ class TestSetSmBandwidthScan:
     """Tests for TowerScanner.set_sm_bandwidth_scan() — bandwidthScan via _snmp_set_string()."""
 
     def test_delegates_to_snmp_set_string(self, scanner):
-        """GIVEN set_sm_bandwidth_scan call THEN _snmp_set_string is called once."""
+        """GIVEN set_sm_bandwidth_scan call THEN _snmp_set_string is called once with SM timeouts."""
         with patch.object(
             scanner, "_snmp_set_string", return_value=(True, "OK")
         ) as mock_set:
             scanner.set_sm_bandwidth_scan("192.168.1.20", 20)
         mock_set.assert_called_once()
+        _, kwargs = mock_set.call_args
+        assert kwargs.get("timeout") == TowerScanner.SM_SNMP_TIMEOUT, (
+            f"Expected SM_SNMP_TIMEOUT={TowerScanner.SM_SNMP_TIMEOUT}, got {kwargs.get('timeout')}"
+        )
+        assert kwargs.get("retries") == TowerScanner.SM_SNMP_RETRIES, (
+            f"Expected SM_SNMP_RETRIES={TowerScanner.SM_SNMP_RETRIES}, got {kwargs.get('retries')}"
+        )
 
     def test_passes_sm_bw_scan_oid(self, scanner):
         """GIVEN set_sm_bandwidth_scan THEN _snmp_set_string receives SM_BW_SCAN_OID."""
@@ -309,12 +323,17 @@ class TestSetSmBandwidthScan:
 
 
 class TestGetSmScanList:
-    """Tests for TowerScanner.get_sm_scan_list() — rfScanList GET via _snmp_get_oid()."""
+    """Tests for TowerScanner.get_sm_scan_list() — rfScanList GET via _snmp_get_oid_sm().
+
+    Note: get_sm_scan_list() now calls _snmp_get_oid_sm() (not _snmp_get_oid) so that
+    it tries ALL communities and uses SM-specific timeouts (Issues #2 and #3).
+    Tests mock _snmp_get_oid_sm to exercise the parsing and result-handling logic.
+    """
 
     def test_returns_parsed_freq_list_on_success(self, scanner):
         """GIVEN SNMP GET returns '3650000, 3660000' THEN returns (True, [3650000, 3660000], 'OK')."""
         with patch.object(
-            scanner, "_snmp_get_oid", return_value=(True, "3650000, 3660000", "OK")
+            scanner, "_snmp_get_oid_sm", return_value=(True, "3650000, 3660000", "OK")
         ):
             ok, freqs, msg = scanner.get_sm_scan_list("192.168.1.20")
         assert ok is True
@@ -324,7 +343,9 @@ class TestGetSmScanList:
     def test_returns_empty_list_on_snmp_failure(self, scanner):
         """GIVEN SNMP GET fails THEN returns (False, [], error_msg)."""
         with patch.object(
-            scanner, "_snmp_get_oid", return_value=(False, "", "Timeout")
+            scanner,
+            "_snmp_get_oid_sm",
+            return_value=(False, "", "all communities failed: Timeout"),
         ):
             ok, freqs, msg = scanner.get_sm_scan_list("192.168.1.20")
         assert ok is False
@@ -334,7 +355,7 @@ class TestGetSmScanList:
     def test_parses_single_frequency(self, scanner):
         """GIVEN SNMP GET returns '3650000' THEN returns [3650000]."""
         with patch.object(
-            scanner, "_snmp_get_oid", return_value=(True, "3650000", "OK")
+            scanner, "_snmp_get_oid_sm", return_value=(True, "3650000", "OK")
         ):
             ok, freqs, msg = scanner.get_sm_scan_list("192.168.1.20")
         assert ok is True
@@ -344,7 +365,7 @@ class TestGetSmScanList:
         """GIVEN '3647500, 3650000, 3652500' THEN returns list of 3 ints."""
         with patch.object(
             scanner,
-            "_snmp_get_oid",
+            "_snmp_get_oid_sm",
             return_value=(True, "3647500, 3650000, 3652500", "OK"),
         ):
             ok, freqs, _ = scanner.get_sm_scan_list("192.168.1.20")
@@ -352,48 +373,78 @@ class TestGetSmScanList:
 
     def test_handles_empty_response(self, scanner):
         """GIVEN SNMP GET returns empty string THEN returns (True, [], 'OK')."""
-        with patch.object(scanner, "_snmp_get_oid", return_value=(True, "", "OK")):
+        with patch.object(scanner, "_snmp_get_oid_sm", return_value=(True, "", "OK")):
             ok, freqs, msg = scanner.get_sm_scan_list("192.168.1.20")
         assert ok is True
         assert freqs == []
 
     def test_handles_whitespace_only_response(self, scanner):
         """GIVEN SNMP GET returns whitespace THEN returns (True, [], 'OK')."""
-        with patch.object(scanner, "_snmp_get_oid", return_value=(True, "   ", "OK")):
+        with patch.object(
+            scanner, "_snmp_get_oid_sm", return_value=(True, "   ", "OK")
+        ):
             ok, freqs, _ = scanner.get_sm_scan_list("192.168.1.20")
         assert freqs == []
 
     def test_uses_rf_scan_list_oid(self, scanner):
-        """GIVEN get_sm_scan_list THEN _snmp_get_oid is called with RF_SCAN_LIST_OID."""
+        """GIVEN get_sm_scan_list THEN _snmp_get_oid_sm is called with RF_SCAN_LIST_OID."""
         with patch.object(
-            scanner, "_snmp_get_oid", return_value=(True, "3650000", "OK")
+            scanner, "_snmp_get_oid_sm", return_value=(True, "3650000", "OK")
         ) as mock_get:
             scanner.get_sm_scan_list("192.168.1.20")
-        _, call_args = mock_get.call_args
-        # _snmp_get_oid(ip, oid) — oid is positional arg [1]
+        # _snmp_get_oid_sm(ip, oid) — oid is positional arg [1]
         positional = mock_get.call_args.args
         assert positional[1] == TowerScanner.RF_SCAN_LIST_OID
 
     def test_passes_correct_ip(self, scanner):
-        """GIVEN IP '10.0.0.5' THEN _snmp_get_oid is called with that IP."""
+        """GIVEN IP '10.0.0.5' THEN _snmp_get_oid_sm is called with that IP."""
         with patch.object(
-            scanner, "_snmp_get_oid", return_value=(True, "3650000", "OK")
+            scanner, "_snmp_get_oid_sm", return_value=(True, "3650000", "OK")
         ) as mock_get:
             scanner.get_sm_scan_list("10.0.0.5")
         positional = mock_get.call_args.args
         assert positional[0] == "10.0.0.5"
+
+    def test_snmp_get_oid_raw_called_with_sm_timeouts(self, scanner):
+        """REGRESSION Issue #3: _snmp_get_oid_raw must be called with SM_SNMP_TIMEOUT=8
+        and SM_SNMP_RETRIES=3, NOT the AP-level defaults (timeout=5, retries=2).
+
+        Patches _snmp_get_oid_raw directly (bypassing _snmp_get_oid_sm) so the actual
+        call path from get_sm_scan_list → _snmp_get_oid_sm → _snmp_get_oid_raw is
+        fully exercised and SM timeout constants are verified at the wire level.
+        """
+        with patch.object(
+            scanner, "_snmp_get_oid_raw", return_value=(True, "3650000", "OK")
+        ) as mock_raw:
+            ok, freqs, msg = scanner.get_sm_scan_list("192.168.1.20")
+
+        assert ok is True
+        assert freqs == [3650000]
+        # Assert SM-specific timeout/retries were forwarded
+        _, kwargs = mock_raw.call_args
+        assert kwargs.get("timeout") == TowerScanner.SM_SNMP_TIMEOUT, (
+            f"Expected SM_SNMP_TIMEOUT={TowerScanner.SM_SNMP_TIMEOUT}, got {kwargs.get('timeout')}"
+        )
+        assert kwargs.get("retries") == TowerScanner.SM_SNMP_RETRIES, (
+            f"Expected SM_SNMP_RETRIES={TowerScanner.SM_SNMP_RETRIES}, got {kwargs.get('retries')}"
+        )
 
 
 # ── get_sm_bandwidth_scan() ───────────────────────────────────────────────────
 
 
 class TestGetSmBandwidthScan:
-    """Tests for TowerScanner.get_sm_bandwidth_scan() — bandwidthScan GET via _snmp_get_oid()."""
+    """Tests for TowerScanner.get_sm_bandwidth_scan() — bandwidthScan GET via _snmp_get_oid_sm().
+
+    Note: get_sm_bandwidth_scan() now calls _snmp_get_oid_sm() (not _snmp_get_oid) so that
+    it tries ALL communities and uses SM-specific timeouts (Issues #2 and #3).
+    Tests mock _snmp_get_oid_sm to exercise the parsing and result-handling logic.
+    """
 
     def test_returns_parsed_bw_list_on_success(self, scanner):
         """GIVEN SNMP GET returns '5.0 MHz, 20.0 MHz' THEN returns (True, ['5.0 MHz', '20.0 MHz'], 'OK')."""
         with patch.object(
-            scanner, "_snmp_get_oid", return_value=(True, "5.0 MHz, 20.0 MHz", "OK")
+            scanner, "_snmp_get_oid_sm", return_value=(True, "5.0 MHz, 20.0 MHz", "OK")
         ):
             ok, bws, msg = scanner.get_sm_bandwidth_scan("192.168.1.20")
         assert ok is True
@@ -403,7 +454,9 @@ class TestGetSmBandwidthScan:
     def test_returns_empty_list_on_snmp_failure(self, scanner):
         """GIVEN SNMP GET fails THEN returns (False, [], error_msg)."""
         with patch.object(
-            scanner, "_snmp_get_oid", return_value=(False, "", "No SNMP response")
+            scanner,
+            "_snmp_get_oid_sm",
+            return_value=(False, "", "all communities failed: No SNMP response"),
         ):
             ok, bws, msg = scanner.get_sm_bandwidth_scan("192.168.1.20")
         assert ok is False
@@ -412,7 +465,7 @@ class TestGetSmBandwidthScan:
     def test_parses_single_bandwidth(self, scanner):
         """GIVEN SNMP GET returns '20.0 MHz' THEN returns ['20.0 MHz']."""
         with patch.object(
-            scanner, "_snmp_get_oid", return_value=(True, "20.0 MHz", "OK")
+            scanner, "_snmp_get_oid_sm", return_value=(True, "20.0 MHz", "OK")
         ):
             ok, bws, _ = scanner.get_sm_bandwidth_scan("192.168.1.20")
         assert ok is True
@@ -422,7 +475,7 @@ class TestGetSmBandwidthScan:
         """GIVEN '10.0 MHz, 15.0 MHz, 20.0 MHz' THEN returns list of 3 strings."""
         with patch.object(
             scanner,
-            "_snmp_get_oid",
+            "_snmp_get_oid_sm",
             return_value=(True, "10.0 MHz, 15.0 MHz, 20.0 MHz", "OK"),
         ):
             ok, bws, _ = scanner.get_sm_bandwidth_scan("192.168.1.20")
@@ -430,31 +483,55 @@ class TestGetSmBandwidthScan:
 
     def test_handles_empty_response(self, scanner):
         """GIVEN SNMP GET returns empty string THEN returns (True, [], 'OK')."""
-        with patch.object(scanner, "_snmp_get_oid", return_value=(True, "", "OK")):
+        with patch.object(scanner, "_snmp_get_oid_sm", return_value=(True, "", "OK")):
             ok, bws, msg = scanner.get_sm_bandwidth_scan("192.168.1.20")
         assert ok is True
         assert bws == []
 
     def test_handles_whitespace_only_response(self, scanner):
         """GIVEN SNMP GET returns whitespace THEN returns (True, [], 'OK')."""
-        with patch.object(scanner, "_snmp_get_oid", return_value=(True, "  ", "OK")):
+        with patch.object(scanner, "_snmp_get_oid_sm", return_value=(True, "  ", "OK")):
             ok, bws, _ = scanner.get_sm_bandwidth_scan("192.168.1.20")
         assert bws == []
 
     def test_uses_sm_bw_scan_oid(self, scanner):
-        """GIVEN get_sm_bandwidth_scan THEN _snmp_get_oid is called with SM_BW_SCAN_OID."""
+        """GIVEN get_sm_bandwidth_scan THEN _snmp_get_oid_sm is called with SM_BW_SCAN_OID."""
         with patch.object(
-            scanner, "_snmp_get_oid", return_value=(True, "20.0 MHz", "OK")
+            scanner, "_snmp_get_oid_sm", return_value=(True, "20.0 MHz", "OK")
         ) as mock_get:
             scanner.get_sm_bandwidth_scan("192.168.1.20")
         positional = mock_get.call_args.args
         assert positional[1] == TowerScanner.SM_BW_SCAN_OID
 
     def test_passes_correct_ip(self, scanner):
-        """GIVEN IP '10.0.0.7' THEN _snmp_get_oid is called with that IP."""
+        """GIVEN IP '10.0.0.7' THEN _snmp_get_oid_sm is called with that IP."""
         with patch.object(
-            scanner, "_snmp_get_oid", return_value=(True, "20.0 MHz", "OK")
+            scanner, "_snmp_get_oid_sm", return_value=(True, "20.0 MHz", "OK")
         ) as mock_get:
             scanner.get_sm_bandwidth_scan("10.0.0.7")
         positional = mock_get.call_args.args
         assert positional[0] == "10.0.0.7"
+
+    def test_snmp_get_oid_raw_called_with_sm_timeouts(self, scanner):
+        """REGRESSION Issue #3: _snmp_get_oid_raw must be called with SM_SNMP_TIMEOUT=8
+        and SM_SNMP_RETRIES=3, NOT the AP-level defaults (timeout=5, retries=2).
+
+        Patches _snmp_get_oid_raw directly (bypassing _snmp_get_oid_sm) so the actual
+        call path from get_sm_bandwidth_scan → _snmp_get_oid_sm → _snmp_get_oid_raw is
+        fully exercised and SM timeout constants are verified at the wire level.
+        """
+        with patch.object(
+            scanner, "_snmp_get_oid_raw", return_value=(True, "20.0 MHz", "OK")
+        ) as mock_raw:
+            ok, bws, msg = scanner.get_sm_bandwidth_scan("192.168.1.20")
+
+        assert ok is True
+        assert bws == ["20.0 MHz"]
+        # Assert SM-specific timeout/retries were forwarded
+        _, kwargs = mock_raw.call_args
+        assert kwargs.get("timeout") == TowerScanner.SM_SNMP_TIMEOUT, (
+            f"Expected SM_SNMP_TIMEOUT={TowerScanner.SM_SNMP_TIMEOUT}, got {kwargs.get('timeout')}"
+        )
+        assert kwargs.get("retries") == TowerScanner.SM_SNMP_RETRIES, (
+            f"Expected SM_SNMP_RETRIES={TowerScanner.SM_SNMP_RETRIES}, got {kwargs.get('retries')}"
+        )


### PR DESCRIPTION
## Summary
- SM-specific timeouts (`SM_SNMP_TIMEOUT=8`, `SM_SNMP_RETRIES=3`) ahora se aplican end-to-end en GET y SET
- SMs skipeados por GET failure ahora se trackean en `errors`, `sm_skipped`, y audit log
- Deduplicación de BW normaliza strings antes de comparar (evita duplicados `"20 MHz"` vs `"20.0 MHz"`)
- merged lists capadas en `SM_SCAN_LIST_MAX_ENTRIES=8`
- Tests de regresión para SM timeout path en GET y SET (scan list + bandwidth scan)
- `parse_scan_list()` protegida con try/except en `get_sm_scan_list()`

## Changes
| File | What changed |
|------|-------------|
| `app/tower_scan.py` | `_snmp_get_oid_raw` acepta timeout/retries; SM GET/SET usan SM constants; parse_scan_list con try/except |
| `app/freq_apply_manager.py` | SM skipped tracking, audit `skipped_sm_count`, normalización BW, scan list cap, helper `_normalize_bw()` |
| `tests/test_tower_scan_set.py` | Regression tests para SM timeouts en GET/SET paths |
| `tests/test_freq_apply_manager.py` | Mocks actualizados para nuevas firmas |

## Test Plan
```
py -3.13 -m pytest tests/test_tower_scan_set.py tests/test_freq_apply_manager.py -v
# 78 passed
```